### PR TITLE
add a threshold parameter to the rasterization of gmm

### DIFF
--- a/modules/algebra/include/Gaussian3D.h
+++ b/modules/algebra/include/Gaussian3D.h
@@ -62,7 +62,7 @@ get_rasterized(const Gaussian3Ds &gmm, const Floats &weights, double cell_width,
  */
 IMPALGEBRAEXPORT DenseGrid3D<double>
 get_rasterized_fast(const Gaussian3Ds &gmm, const Floats &weights,
-                    double cell_width, const BoundingBox3D &bb);
+                    double cell_width, const BoundingBox3D &bb, double factor=2.5);
 
 IMPALGEBRA_END_NAMESPACE
 

--- a/modules/algebra/src/Gaussian3D.cpp
+++ b/modules/algebra/src/Gaussian3D.cpp
@@ -104,7 +104,7 @@ DensityGrid get_rasterized(const Gaussian3Ds &gmm, const Floats &weights,
 }
 
 DensityGrid get_rasterized_fast(const Gaussian3Ds &gmm, const Floats &weights,
-                                double cell_width, const BoundingBox3D &bb) {
+                                double cell_width, const BoundingBox3D &bb, double factor) {
   DensityGrid ret(cell_width, bb, 0);
   for (unsigned int ng = 0; ng < gmm.size(); ng++) {
     IMP_Eigen::Matrix3d covar = get_covariance(gmm[ng]);
@@ -118,7 +118,7 @@ DensityGrid get_rasterized_fast(const Gaussian3Ds &gmm, const Floats &weights,
     double pre(get_gaussian_eval_prefactor(determinant));
     IMP_Eigen::Vector3d evals = covar.eigenvalues().real();
     double maxeval = sqrt(evals.maxCoeff());
-    double cutoff = 2.5 * maxeval;
+    double cutoff = factor * maxeval;
     double cutoff2 = cutoff * cutoff;
     Vector3D c = gmm[ng].get_center();
     Vector3D lower = c - Vector3D(cutoff, cutoff, cutoff);


### PR DESCRIPTION
This allows to better control the approximation made while rasterizing in "fast" mode.