### PR TITLE
Improvements to rigid body derivatives

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,32 @@ ChangeLog {#changelog}
 - The `rg` tool (part of the IMP::saxs module, used to compute radius of
   gyration from a SAXS profile) is now called `compute_rg` for consistency
   with other SAXS tools and to avoid conflicts with other packages.
+- IMP::algebra::Rotation3D::get_derivative(),
+  IMP::algebra::Rotation3D::get_gradient(),
+  IMP::algebra::get_gradient_of_composed_with_respect_to_first(), and
+  IMP::algebra::get_gradient_of_composed_with_respect_to_second() have been
+  deprecated and are superseded by
+  IMP::algebra::Rotation3D::get_gradient_of_rotated(),
+  IMP::algebra::Rotation3D::get_jacobian_of_rotated(),
+  IMP::algebra::get_jacobian_of_composed_wrt_first(), and
+  IMP::algebra::get_jacobian_of_composed_wrt_second(), respectively. By
+  default, the derivatives are now computed with respect to the unnormalized
+  quaternion and do not include the normalization operation.
+- New methods are added to compute adjoint derivatives (reverse-mode
+  sensitivities) for compositions and actions of IMP::algebra::Rotation3D and
+  IMP::algebra::Transformation3D upon 3D vectors.
+- Fixed a bug in nested rigid body derivative accumulation, where derivatives
+  with respect to quaternions were incorrectly projected to be orthogonal to
+  the quaternion.
+- Reimplemented rigid body derivative accumulation to use the new adjoint
+  methods. The many-argument versions of
+  IMP::core::RigidBody::add_to_derivatives(),
+  IMP::core::RigidBody::add_to_rotational_derivatives(), and
+  IMP::core::NonRigidMember::add_to_internal_rotational_derivatives(), which
+  previously pulled adjoints from member global reference frame to member
+  local reference frame and parent global reference frame are now deprecated.
+  Pullback functionality is now handled by
+  IMP::core::RigidBody::pull_back_members_adjoints().
 
 # 2.11.1 - 2019-07-18 # {#changelog_2_11_1}
 - Bugfix: fix build system failures with CMake 3.12 and 3.13, and on Windows.

--- a/modules/algebra/include/Rotation3D.h
+++ b/modules/algebra/include/Rotation3D.h
@@ -22,6 +22,11 @@
 
 IMPALGEBRA_BEGIN_NAMESPACE
 
+typedef Vector4D Rotation3DAdjoint;
+typedef std::pair<Vector3D, Rotation3DAdjoint> RotatedVector3DAdjoint;
+typedef std::pair<Rotation3DAdjoint, Rotation3DAdjoint>
+    ComposeRotation3DAdjoint;
+
 #if !defined(IMP_DOXYGEN) && !defined(SWIG)
 class Rotation3D;
 Rotation3D compose(const Rotation3D &a, const Rotation3D &b);
@@ -174,6 +179,24 @@ class IMPALGEBRAEXPORT Rotation3D : public GeometricPrimitiveD<3> {
     if (!has_cache_) fill_cache();
     return Vector3D(o * matrix_[0], o * matrix_[1], o * matrix_[2]);
   }
+
+#ifndef SWIG
+  //! Get adjoint of inputs to `get_rotated` from adjoint of output
+  /** Compute the adjoint (reverse-mode sensitivity) of input vector
+      to `get_rotated` and this rotation from the adjoint of the
+      output vector.
+   */
+  void get_rotated_adjoint(const Vector3D &v, const Vector3D &Dw,
+                           Vector3D *Dv, Rotation3DAdjoint *Dr) const;
+#endif
+
+  //! Get adjoint of inputs to `get_rotated` from adjoint of output
+  /** Compute the adjoint (reverse-mode sensitivity) of input vector
+      to `get_rotated` and this rotation from the adjoint of the
+      output vector.
+   */
+  RotatedVector3DAdjoint
+  get_rotated_adjoint(const Vector3D &v, const Vector3D &Dw) const;
 
   //! Get only the requested rotation coordinate of the vector
   double get_rotated_one_coordinate(const Vector3D &o,
@@ -479,6 +502,23 @@ inline Rotation3D compose(const Rotation3D &a, const Rotation3D &b) {
                     a.v_[0] * b.v_[3] + a.v_[1] * b.v_[2] - a.v_[2] * b.v_[1] +
                         a.v_[3] * b.v_[0]);
 }
+
+#ifndef SWIG
+//! Get adjoint of inputs to `compose` from adjoint of output
+/** Compute the adjoint (reverse-mode sensitivity) of input rotations
+    to `compose` from the adjoint of the output rotation.
+ */
+IMPALGEBRAEXPORT void
+compose_adjoint(const Rotation3D &A, const Rotation3D &B, Vector4D DC,
+                Rotation3DAdjoint *DA, Rotation3DAdjoint *DB);
+#endif
+
+//! Get adjoint of inputs to `compose` from adjoint of output
+/** Compute the adjoint (reverse-mode sensitivity) of input rotations
+    to `compose` from the adjoint of the output rotation.
+ */
+IMPALGEBRAEXPORT ComposeRotation3DAdjoint
+compose_adjoint(const Rotation3D &A, const Rotation3D &B, const Rotation3DAdjoint &DC);
 
 /** \name Euler Angles
     There are many conventions for how to define Euler angles, based on choices

--- a/modules/algebra/include/Rotation3D.h
+++ b/modules/algebra/include/Rotation3D.h
@@ -270,7 +270,7 @@ class IMPALGEBRAEXPORT Rotation3D : public GeometricPrimitiveD<3> {
   Vector3D get_gradient_of_rotated(const Vector3D &v, unsigned int i,
                                    bool wrt_unnorm = false) const;
 
-  IMPALGEBRA_DEPRECATED_METHOD_DECL(2.12);
+  IMPALGEBRA_DEPRECATED_METHOD_DECL(2.12)
   Vector3D get_derivative(const Vector3D &v, unsigned int i,
                           bool wrt_unnorm = true) const;
 
@@ -289,7 +289,7 @@ class IMPALGEBRAEXPORT Rotation3D : public GeometricPrimitiveD<3> {
   Eigen::MatrixXd get_jacobian_of_rotated(
     const Eigen::Vector3d &v, bool wrt_unnorm = false) const;
 
-  IMPALGEBRA_DEPRECATED_METHOD_DECL(2.12);
+  IMPALGEBRA_DEPRECATED_METHOD_DECL(2.12)
   Eigen::MatrixXd get_gradient(
     const Eigen::Vector3d &v, bool wrt_unnorm = true) const;
 
@@ -322,7 +322,7 @@ IMP_VALUES(Rotation3D, Rotation3Ds);
 IMPALGEBRAEXPORT Eigen::MatrixXd get_jacobian_of_composed_wrt_first(
   const Rotation3D &q, const Rotation3D &p, bool wrt_unnorm = false);
 
-IMPALGEBRA_DEPRECATED_FUNCTION_DECL(2.12);
+IMPALGEBRA_DEPRECATED_FUNCTION_DECL(2.12)
 IMPALGEBRAEXPORT Eigen::MatrixXd
   get_gradient_of_composed_with_respect_to_first(
     const Rotation3D &q, const Rotation3D &p, bool wrt_unnorm = true);
@@ -345,7 +345,7 @@ IMPALGEBRAEXPORT Eigen::MatrixXd
 IMPALGEBRAEXPORT Eigen::MatrixXd get_jacobian_of_composed_wrt_second(
   const Rotation3D &q, const Rotation3D &p, bool wrt_unnorm = false);
 
-IMPALGEBRA_DEPRECATED_FUNCTION_DECL(2.12);
+IMPALGEBRA_DEPRECATED_FUNCTION_DECL(2.12)
 IMPALGEBRAEXPORT Eigen::MatrixXd
   get_gradient_of_composed_with_respect_to_second(
     const Rotation3D &q, const Rotation3D &p, bool wrt_unnorm = true);

--- a/modules/algebra/include/Rotation3D.h
+++ b/modules/algebra/include/Rotation3D.h
@@ -249,10 +249,7 @@ class IMPALGEBRAEXPORT Rotation3D : public GeometricPrimitiveD<3> {
 
   IMPALGEBRA_DEPRECATED_METHOD_DECL(2.12);
   Vector3D get_derivative(const Vector3D &v, unsigned int i,
-                          bool wrt_unnorm = true) {
-    IMPALGEBRA_DEPRECATED_METHOD_DEF(2.12, "Use get_gradient_of_rotated(args) instead.");
-    return get_gradient_of_rotated(v, i, wrt_unnorm);
-  }
+                          bool wrt_unnorm = true) const;
 
   //! Return the Jacobian of rotated vector wrt the quaternion.
   /** Given the rotation \f$x = R(q) v\f$, where \f$v\f$ is a vector,
@@ -271,10 +268,7 @@ class IMPALGEBRAEXPORT Rotation3D : public GeometricPrimitiveD<3> {
 
   IMPALGEBRA_DEPRECATED_METHOD_DECL(2.12);
   Eigen::MatrixXd get_gradient(
-    const Eigen::Vector3d &v, bool wrt_unnorm = true) const {
-    IMPALGEBRA_DEPRECATED_METHOD_DEF(2.12, "Use get_jacobian_of_rotated(args) instead.");
-    return get_jacobian_of_rotated(v, wrt_unnorm);
-  }
+    const Eigen::Vector3d &v, bool wrt_unnorm = true) const;
 
   /** Return true is the rotation is valid, false if
       invalid or not initialized (e.g., only initialized by

--- a/modules/algebra/include/Transformation3D.h
+++ b/modules/algebra/include/Transformation3D.h
@@ -23,6 +23,11 @@ class Transformation3D;
 Transformation3D compose(const Transformation3D &a, const Transformation3D &b);
 #endif
 
+typedef std::pair<Vector4D, Vector3D> Transformation3DAdjoint;
+typedef std::pair<Vector3D, Transformation3DAdjoint> TransformedVector3DAdjoint;
+typedef std::pair<Transformation3DAdjoint, Transformation3DAdjoint>
+    ComposeTransformation3DAdjoint;
+
 //! Simple 3D transformation class
 /** The rotation is applied first, and then the point is translated.
     \see IMP::core::Transform
@@ -44,6 +49,25 @@ class IMPALGEBRAEXPORT Transformation3D : public GeometricPrimitiveD<3> {
   Vector3D get_transformed(const Vector3D &o) const {
     return rot_.get_rotated(o) + trans_;
   }
+
+#ifndef SWIG
+  //! Get adjoint of inputs to `get_transformed` from adjoint of output
+  /** Compute the adjoint (reverse-mode sensitivity) of input vector
+      to `get_transformed` and this transformation from the adjoint of the
+      output vector.
+   */
+  void get_transformed_adjoint(const Vector3D &v, const Vector3D &Dw,
+                               Vector3D *Dv, Transformation3DAdjoint *DT) const;
+#endif
+
+  //! Get adjoint of inputs to `get_transformed` from adjoint of output
+  /** Compute the adjoint (reverse-mode sensitivity) of input vector
+      to `get_transformed` and this transformation from the adjoint of the
+      output vector.
+   */
+  TransformedVector3DAdjoint
+  get_transformed_adjoint(const Vector3D &v, const Vector3D &Dw) const;
+
   //! Apply transformation (rotate and then translate)
   Vector3D operator*(const Vector3D &v) const { return get_transformed(v); }
   /** Compose two rigid transformation such that for any vector v
@@ -126,6 +150,25 @@ inline Transformation3D compose(const Transformation3D &a,
   return Transformation3D(compose(a.get_rotation(), b.get_rotation()),
                           a.get_transformed(b.get_translation()));
 }
+
+#ifndef SWIG
+//! Get adjoint of inputs to `compose` from adjoint of output
+/** Compute the adjoint (reverse-mode sensitivity) of input transformations
+    to `compose` from the adjoint of the output transformation.
+ */
+IMPALGEBRAEXPORT void
+compose_adjoint(const Transformation3D &TA, const Transformation3D &TB,
+                const Transformation3DAdjoint &DTC,
+                Transformation3DAdjoint *DTA, Transformation3DAdjoint *DTB);
+#endif
+
+//! Get adjoint of inputs to `compose` from adjoint of output
+/** Compute the adjoint (reverse-mode sensitivity) of input transformations
+    to `compose` from the adjoint of the output transformation.
+ */
+ComposeTransformation3DAdjoint
+compose_adjoint(const Transformation3D &TA, const Transformation3D &TB,
+                const Transformation3DAdjoint &DTC);
 
 class Transformation2D;
 

--- a/modules/algebra/include/internal/quaternion_derivatives.h
+++ b/modules/algebra/include/internal/quaternion_derivatives.h
@@ -14,10 +14,12 @@
 
 IMPALGEBRA_BEGIN_INTERNAL_NAMESPACE
 
-//! Get 4x4 matrix that projects a matrix to the tangent space of q.
-inline Eigen::Matrix4d get_projection(
+//! Get Jacobian of l2-normalization of vector.
+inline Eigen::Matrix4d get_normalization_jacobian(
     const Eigen::Vector4d &q) {
-  return Eigen::Matrix4d::Identity() - q * q.transpose();
+  double qnorm = q.norm();
+  Eigen::Vector4d x = q / qnorm;
+  return (Eigen::Matrix4d::Identity() - x * x.transpose()) / qnorm;
 }
 
 //! Get the skew-symmetric matrix that is equivalent to the cross product.
@@ -33,15 +35,15 @@ inline Eigen::Matrix3d get_cross_matrix(
   return vcross;
 }
 
-//! Get gradient of rotated vector wrt quaternion of rotation.
+//! Get Jacobian of rotated vector wrt quaternion of rotation.
 /** \param[in] Q quaternion of rotation (assumed to be normalized)
     \param[in] v vector to be rotated by rotation R(Q)
-    \param[in] projected Project gradient onto tangent space to Q.
-                         Equivalent to differentiating wrt Q/||Q||
-                         instead of Q.
+    \param[in] wrt_unnorm Jacobian is computed wrt unnormalized quaternion.
+                          Rotation includes a normalization operation, and
+                          the columns are projected to the tangent space at Q.
  */
-inline Eigen::Matrix<double,3,4> get_gradient_of_rotated(
-    const Eigen::Vector4d& Q, const Eigen::Vector3d& v, bool projected = true) {
+inline Eigen::Matrix<double,3,4> get_jacobian_of_rotated(
+    const Eigen::Vector4d& Q, const Eigen::Vector3d& v, bool wrt_unnorm = false) {
   Eigen::Matrix<double,3,4> dRv_dq;
   Eigen::Matrix3d vcross;
   Eigen::Vector3d q = Q.tail(3);
@@ -54,49 +56,49 @@ inline Eigen::Matrix<double,3,4> get_gradient_of_rotated(
          + q * v.transpose()
          - q0 * vcross);
 
-  return (!projected) ? dRv_dq : dRv_dq * get_projection(Q);
+  return (!wrt_unnorm) ? dRv_dq : dRv_dq * get_normalization_jacobian(Q);
 }
 
-//! Get gradient of Hamilton product of two quaternions wrt first quaternion.
+//! Get Jacobian of Hamilton product of two quaternions wrt first quaternion.
 /** The combined quaternion is S = Q P.
     \param[in] Q first quaternion of rotation (assumed to be normalized)
     \param[in] P second quaternion of rotation (assumed to be normalized)
-    \param[in] projected Project gradient onto tangent space to Q.
-                         Equivalent to differentiating wrt Q/||Q||
-                         instead of Q.
+    \param[in] wrt_unnorm Jacobian is computed wrt unnormalized quaternion.
+                          Rotation includes a normalization operation, and
+                          the columns are projected to the tangent space at Q.
  */
 inline Eigen::Matrix4d
-  get_gradient_of_composed_wrt_first(
+  get_jacobian_of_composed_wrt_first(
       const Eigen::Vector4d& Q, const Eigen::Vector4d& P,
-      bool projected = true) {
+      bool wrt_unnorm = false) {
   Eigen::Matrix4d dqp_dq;
   dqp_dq.leftCols(1) = P;
   dqp_dq.topRightCorner(1, 3) = -P.tail(3).transpose();
   dqp_dq.bottomRightCorner(3, 3) =
     P[0] * Eigen::Matrix3d::Identity()
     - get_cross_matrix(P.tail(3));
-  return (!projected) ? dqp_dq : dqp_dq * get_projection(Q);
+  return (!wrt_unnorm) ? dqp_dq : dqp_dq * get_normalization_jacobian(Q);
 }
 
-//! Get gradient of Hamilton product of two quaternions wrt second quaternion.
+//! Get Jacobian of Hamilton product of two quaternions wrt second quaternion.
 /** The combined quaternion is S = Q P.
     \param[in] Q first quaternion of rotation (assumed to be normalized)
     \param[in] P second quaternion of rotation (assumed to be normalized)
-    \param[in] projected Project gradient onto tangent space to P.
-                         Equivalent to differentiating wrt P/||P||
-                         instead of P.
+    \param[in] wrt_unnorm Jacobian is computed wrt unnormalized quaternion.
+                          Rotation includes a normalization operation, and
+                          the columns are projected to the tangent space at P.
  */
 inline Eigen::Matrix4d
-  get_gradient_of_composed_wrt_second(
+  get_jacobian_of_composed_wrt_second(
       const Eigen::Vector4d& Q, const Eigen::Vector4d& P,
-      bool projected = true) {
+      bool wrt_unnorm = false) {
   Eigen::Matrix4d dqp_dp;
   dqp_dp.leftCols(1) = Q;
   dqp_dp.topRightCorner(1, 3) = -Q.tail(3).transpose();
   dqp_dp.bottomRightCorner(3, 3) =
     Q[0] * Eigen::Matrix3d::Identity()
     + get_cross_matrix(Q.tail(3));
-  return (!projected) ? dqp_dp : dqp_dp * get_projection(P);
+  return (!wrt_unnorm) ? dqp_dp : dqp_dp * get_normalization_jacobian(P);
 }
 
 IMPALGEBRA_END_INTERNAL_NAMESPACE

--- a/modules/algebra/pyext/swig.i-in
+++ b/modules/algebra/pyext/swig.i-in
@@ -221,6 +221,13 @@ namespace IMP {
 
    %template(get_transformation_aligning_first_to_second) get_transformation_aligning_first_to_second<IMP::Vector<IMP::algebra::VectorD<3> >, IMP::Vector<IMP::algebra::VectorD<3> > >;
    // rotation operations
+
+   %template(_RotatedVector3DAdjoint) ::std::pair<IMP::algebra::VectorD<3>,IMP::algebra::VectorD<4> >;
+   %template(_ComposeRotation3DAdjoint) ::std::pair<IMP::algebra::VectorD<4>,IMP::algebra::VectorD<4> >;
+
+   %template(_Transformation3DAdjoint) ::std::pair<IMP::algebra::VectorD<4>,IMP::algebra::VectorD<3> >;
+   %template(_TransformedVector3DAdjoint) ::std::pair<IMP::algebra::VectorD<3>,std::pair<IMP::algebra::VectorD<4>,IMP::algebra::VectorD<3> > >;
+   %template(_ComposeTransformation3DAdjoint) ::std::pair<std::pair<IMP::algebra::VectorD<4>,IMP::algebra::VectorD<3> >,std::pair<IMP::algebra::VectorD<4>,IMP::algebra::VectorD<3> > >;
  }
 }
 

--- a/modules/algebra/src/Rotation3D.cpp
+++ b/modules/algebra/src/Rotation3D.cpp
@@ -105,45 +105,57 @@ Rotation3D get_rotation_from_matrix(double m11, double m12, double m13,
   return ret;
 }
 
-Vector3D Rotation3D::get_derivative(const Vector3D &v,
-                                    unsigned int i,
-                                    bool projected) const {
+Vector3D Rotation3D::get_gradient_of_rotated(const Vector3D &v,
+                                             unsigned int i,
+                                             bool wrt_unnorm) const {
   IMP_USAGE_CHECK(i < 4, "Invalid derivative component.");
   Eigen::Vector4d q(v_.get_data());
   Eigen::Vector3d V(v.get_data());
-  Eigen::Matrix<double,3,4> dRv_dq = internal::get_gradient_of_rotated(
-    q, V, projected);
+  Eigen::Matrix<double,3,4> dRv_dq = internal::get_jacobian_of_rotated(
+    q, V, wrt_unnorm);
   Vector3D dRv_dqi;
   Eigen::VectorXd::Map(&dRv_dqi[0], 3) = dRv_dq.col(i);
   return dRv_dqi;
 }
 
-Eigen::MatrixXd Rotation3D::get_gradient(
-    const Eigen::Vector3d &v, bool projected) const {
+Eigen::MatrixXd Rotation3D::get_jacobian_of_rotated(
+    const Eigen::Vector3d &v, bool wrt_unnorm) const {
   Eigen::Vector4d q(v_.get_data());
-  return internal::get_gradient_of_rotated(q, v, projected);
+  return internal::get_jacobian_of_rotated(q, v, wrt_unnorm);
 }
 
-Eigen::MatrixXd get_gradient_of_composed_with_respect_to_first(
-    const Rotation3D &q, const Rotation3D &p, bool projected) {
+Eigen::MatrixXd get_jacobian_of_composed_wrt_first(
+    const Rotation3D &q, const Rotation3D &p, bool wrt_unnorm) {
   Eigen::Vector4d Q(q.get_quaternion().get_data());
   Eigen::Vector4d P(p.get_quaternion().get_data());
   if (Q[0] * P[0] - Q.tail(3).dot(P.tail(3)) < 0) {
     // account for compose() canonicalizing rotation
     P *= -1;
   }
-  return internal::get_gradient_of_composed_wrt_first(Q, P, projected);
+  return internal::get_jacobian_of_composed_wrt_first(Q, P, wrt_unnorm);
 }
 
-Eigen::MatrixXd get_gradient_of_composed_with_respect_to_second(
-    const Rotation3D &q, const Rotation3D &p, bool projected) {
+Eigen::MatrixXd get_gradient_of_composed_with_respect_to_first(
+  const Rotation3D &q, const Rotation3D &p, bool wrt_unnorm) {
+  IMPALGEBRA_DEPRECATED_FUNCTION_DEF(2.12, "Use get_jacobian_of_composed_wrt_first(args) instead.");
+  return get_jacobian_of_composed_wrt_first(q, p, wrt_unnorm);
+}
+
+Eigen::MatrixXd get_jacobian_of_composed_wrt_second(
+    const Rotation3D &q, const Rotation3D &p, bool wrt_unnorm) {
   Eigen::Vector4d Q(q.get_quaternion().get_data());
   Eigen::Vector4d P(p.get_quaternion().get_data());
   if (Q[0] * P[0] - Q.tail(3).dot(P.tail(3)) < 0) {
     // account for compose() canonicalizing rotation
     Q *= -1;
   }
-  return internal::get_gradient_of_composed_wrt_second(Q, P, projected);
+  return internal::get_jacobian_of_composed_wrt_second(Q, P, wrt_unnorm);
+}
+
+Eigen::MatrixXd get_gradient_of_composed_with_respect_to_second(
+  const Rotation3D &q, const Rotation3D &p, bool wrt_unnorm) {
+  IMPALGEBRA_DEPRECATED_FUNCTION_DEF(2.12, "Use get_jacobian_of_composed_with_respect_to_second(args) instead.");
+  return get_jacobian_of_composed_wrt_second(q, p, wrt_unnorm);
 }
 
 Rotation3D get_random_rotation_3d() {

--- a/modules/algebra/src/Rotation3D.cpp
+++ b/modules/algebra/src/Rotation3D.cpp
@@ -118,10 +118,29 @@ Vector3D Rotation3D::get_gradient_of_rotated(const Vector3D &v,
   return dRv_dqi;
 }
 
+Vector3D Rotation3D::get_derivative(const Vector3D &v,
+                                    unsigned int i,
+                                    bool wrt_unnorm) const {
+  IMPALGEBRA_DEPRECATED_METHOD_DEF(
+    2.12,
+    "Use get_gradient_of_rotated(args) instead."
+  );
+  return get_gradient_of_rotated(v, i, wrt_unnorm);
+}
+
 Eigen::MatrixXd Rotation3D::get_jacobian_of_rotated(
     const Eigen::Vector3d &v, bool wrt_unnorm) const {
   Eigen::Vector4d q(v_.get_data());
   return internal::get_jacobian_of_rotated(q, v, wrt_unnorm);
+}
+
+Eigen::MatrixXd Rotation3D::get_gradient(
+  const Eigen::Vector3d &v, bool wrt_unnorm) const {
+  IMPALGEBRA_DEPRECATED_METHOD_DEF(
+    2.12,
+    "Use get_jacobian_of_rotated(args) instead."
+  );
+  return get_jacobian_of_rotated(v, wrt_unnorm);
 }
 
 Eigen::MatrixXd get_jacobian_of_composed_wrt_first(

--- a/modules/algebra/src/Transformation3D.cpp
+++ b/modules/algebra/src/Transformation3D.cpp
@@ -12,6 +12,50 @@
 IMPALGEBRA_BEGIN_NAMESPACE
 
 Transformation3D::~Transformation3D() {}
+
+void Transformation3D::get_transformed_adjoint(
+    const Vector3D &v, const Vector3D &Dw,
+    Vector3D *Dv, Transformation3DAdjoint *DT) const {
+  if (!DT) return;
+  rot_.get_rotated_adjoint(v, Dw, Dv, &(DT->first));
+  std::copy(Dw.begin(), Dw.end(), DT->second.begin());
+}
+
+TransformedVector3DAdjoint
+Transformation3D::get_transformed_adjoint(
+    const Vector3D &v, const Vector3D &Dw) const {
+  Vector3D Dv;
+  Transformation3DAdjoint DT;
+  get_transformed_adjoint(v, Dw, &Dv, &DT);
+  return TransformedVector3DAdjoint(Dv, DT);
+}
+
+void compose_adjoint(const Transformation3D &TA, const Transformation3D &TB,
+                     const Transformation3DAdjoint &DTC,
+                     Transformation3DAdjoint *DTA,
+                     Transformation3DAdjoint *DTB) {
+  bool has_DTB = DTB;
+  TA.get_transformed_adjoint(TB.get_translation(), DTC.second,
+                             has_DTB ? &(DTB->second) : nullptr, DTA);
+  if (DTA) {
+    Rotation3DAdjoint DA;
+    compose_adjoint(TA.get_rotation(), TB.get_rotation(), DTC.first, &DA,
+                    has_DTB ? &(DTB->first) : nullptr);
+    DTA->first += DA;
+  } else {
+    compose_adjoint(TA.get_rotation(), TB.get_rotation(), DTC.first, nullptr,
+                    has_DTB ? &(DTB->first) : nullptr);
+  }
+}
+
+ComposeTransformation3DAdjoint
+compose_adjoint(const Transformation3D &TA, const Transformation3D &TB,
+                const Transformation3DAdjoint &DTC) {
+  Transformation3DAdjoint DTA, DTB;
+  compose_adjoint(TA, TB, DTC, &DTA, &DTB);
+  return ComposeTransformation3DAdjoint(DTA, DTB);
+}
+
 Transformation3D Transformation3D::get_inverse() const {
   Rotation3D inv_rot = rot_.get_inverse();
   return Transformation3D(inv_rot, -(inv_rot.get_rotated(trans_)));

--- a/modules/algebra/test/standards_exceptions
+++ b/modules/algebra/test/standards_exceptions
@@ -24,4 +24,4 @@ value_object_exceptions=['DenseDoubleGrid3D',
                          'SparseUnboundedIntGridKD',
                          'Matrix2D', 'Matrix3D',
                          'LinearFit', 'ParabolicFit']
-spelling_exceptions=["xyz", "zyz", "zxz", "kd", "connolly", "rasterized", "rmsd"]
+spelling_exceptions=["xyz", "zyz", "zxz", "kd", "connolly", "rasterized", "rmsd", "wrt"]

--- a/modules/algebra/test/standards_exceptions
+++ b/modules/algebra/test/standards_exceptions
@@ -11,7 +11,7 @@ plural_exceptions=['FixedXYZ', 'FixedZYZ', 'Matrix2D',
                    'UnboundedGridStorage3D',
                    'AxisAnglePair']
 show_exceptions=[]
-function_name_exceptions=['compose', 'reversed_read', 'reversed_write']+\
+function_name_exceptions=['compose', 'compose_adjoint', 'reversed_read', 'reversed_write']+\
     matrix_function_name_exceptions
 value_object_exceptions=['DenseDoubleGrid3D',
                          'DenseFloatGrid3D',

--- a/modules/algebra/test/test_rotation_3d.py
+++ b/modules/algebra/test/test_rotation_3d.py
@@ -28,7 +28,7 @@ class TransformFunct:
     def get_analytic_deriv(self):
         uv = self.q.get_unit_vector()
         r = IMP.algebra.Rotation3D(uv[0], uv[1], uv[2], uv[3])
-        return r.get_derivative(self.x, self.qi)[self.xi]
+        return r.get_gradient_of_rotated(self.x, self.qi, True)[self.xi]
 
 
 class TransformFunct2:
@@ -49,8 +49,8 @@ class TransformFunct2:
     def get_analytic_deriv(self):
         uv = self.q.get_unit_vector()
         q = IMP.algebra.Rotation3D(uv[0], uv[1], uv[2], uv[3])
-        return IMP.algebra.get_gradient_of_composed_with_respect_to_first(
-            q, self.p)[self.pi][self.qi]
+        return IMP.algebra.get_jacobian_of_composed_wrt_first(
+            q, self.p, True)[self.pi][self.qi]
 
 
 class TransformFunct3:

--- a/modules/algebra/test/test_rotation_3d.py
+++ b/modules/algebra/test/test_rotation_3d.py
@@ -28,7 +28,7 @@ class TransformFunct:
     def get_analytic_deriv(self):
         uv = self.q.get_unit_vector()
         r = IMP.algebra.Rotation3D(uv[0], uv[1], uv[2], uv[3])
-        return r.get_gradient_of_rotated(self.x, self.qi, True)[self.xi]
+        return r.get_jacobian_of_rotated(self.x, True)[self.xi][self.qi]
 
 
 class TransformFunct2:
@@ -71,8 +71,8 @@ class TransformFunct3:
     def get_analytic_deriv(self):
         uv = self.p.get_unit_vector()
         p = IMP.algebra.Rotation3D(uv[0], uv[1], uv[2], uv[3])
-        return IMP.algebra.get_gradient_of_composed_with_respect_to_second(
-            self.q, p)[self.pi][self.qi]
+        return IMP.algebra.get_jacobian_of_composed_wrt_second(
+            self.q, p, True)[self.pi][self.qi]
 
 
 class Tests(IMP.test.TestCase):

--- a/modules/core/include/rigid_bodies.h
+++ b/modules/core/include/rigid_bodies.h
@@ -527,7 +527,8 @@ void RigidBody::add_to_derivatives(const algebra::Vector3D &deriv_local,
 
   Eigen::RowVector4d q =
     Eigen::RowVector3d(deriv_global.get_data()) *
-    rot_local_to_global.get_gradient(Eigen::Vector3d(local.get_data()), false);
+    rot_local_to_global.get_jacobian_of_rotated(Eigen::Vector3d(local.get_data()),
+                                                false);
 
   for (unsigned int i = 0; i < 4; ++i) {
     get_model()->add_to_derivative(internal::rigid_body_data().quaternion_[i],
@@ -554,7 +555,7 @@ void RigidBody::add_to_rotational_derivatives(const algebra::Vector4D &other_qde
                                               const algebra::Rotation3D &rot_local_to_global,
                                               DerivativeAccumulator &da) {
   Eigen::MatrixXd derivs =
-    algebra::get_gradient_of_composed_with_respect_to_first(
+    algebra::get_jacobian_of_composed_wrt_first(
       rot_local_to_global, rot_other_to_local, false);
   Eigen::RowVector4d qderiv = Eigen::RowVector4d(other_qderiv.get_data()) * derivs;
   for (unsigned int i = 0; i < 4; ++i) {
@@ -747,7 +748,7 @@ class IMPCOREEXPORT NonRigidMember : public RigidBodyMember {
                                               const algebra::Rotation3D &rot_parent_to_global,
                                               DerivativeAccumulator &da) {
     Eigen::MatrixXd derivs =
-      algebra::get_gradient_of_composed_with_respect_to_second(
+      algebra::get_jacobian_of_composed_wrt_second(
         rot_parent_to_global, rot_local_to_parent, false);
     Eigen::RowVector4d qderiv = Eigen::RowVector4d(local_qderiv.get_data()) * derivs;
     for (unsigned int i = 0; i < 4; ++i) {

--- a/modules/core/include/rigid_bodies.h
+++ b/modules/core/include/rigid_bodies.h
@@ -102,6 +102,10 @@ class IMPCOREEXPORT RigidBody : public XYZ {
 
   static ObjectKey get_constraint_key_1();
 
+  static FloatKeys get_rotation_keys() {
+    return internal::rigid_body_data().quaternion_;
+  }
+
   // setup rigid body attributes with particles in ps, using their
   // center of mass, inertia tensor  to initialize the reference frame
   static void do_setup_particle(Model *m, ParticleIndex pi,

--- a/modules/core/include/rigid_bodies.h
+++ b/modules/core/include/rigid_bodies.h
@@ -400,6 +400,7 @@ class IMPCOREEXPORT RigidBody : public XYZ {
       @param da               Accumulates the output derivative over the rigid body
                               center of mass (translation and rotation torque, quaternion)
    */
+  IMPCORE_DEPRECATED_METHOD_DECL(2.12)
   inline void add_to_derivatives(const algebra::Vector3D &local_derivative,
                           const algebra::Vector3D &local_location,
                           DerivativeAccumulator &da);
@@ -415,6 +416,7 @@ class IMPCOREEXPORT RigidBody : public XYZ {
       @param da                  Accumulates the output derivative over the rigid body
                                  center of mass (translation and rotation torque, quaternion)
   */
+  IMPCORE_DEPRECATED_METHOD_DECL(2.12)
   inline void add_to_derivatives(const algebra::Vector3D &local_derivative,
                           const algebra::Vector3D &global_derivative,
                           const algebra::Vector3D &local_location,
@@ -436,6 +438,7 @@ class IMPCOREEXPORT RigidBody : public XYZ {
                                  global coordinates.
       @param da               Accumulates the output derivatives.
    */
+  IMPCORE_DEPRECATED_METHOD_DECL(2.12)
   inline void add_to_rotational_derivatives(const algebra::Vector4D &other_qderiv,
                                             const algebra::Rotation3D &rot_other_to_local,
                                             const algebra::Rotation3D &rot_local_to_global,
@@ -607,6 +610,7 @@ void RigidBody::add_to_derivatives(const algebra::Vector3D &deriv_local,
                                    const algebra::Vector3D &local,
                                    const algebra::Rotation3D &rot_local_to_global,
                                    DerivativeAccumulator &da) {
+  IMPCORE_DEPRECATED_FUNCTION_DEF(2.12, "Updating of derivatives is now handled after evaluation by RigidBody::pull_back_members_adjoints.");
   // IMP_LOG_TERSE( "Accumulating rigid body derivatives" << std::endl);
   XYZ::add_to_derivatives(deriv_global, da);
 
@@ -627,6 +631,7 @@ void RigidBody::add_to_derivatives(const algebra::Vector3D &deriv_local,
 void RigidBody::add_to_derivatives(const algebra::Vector3D &deriv_local,
                                    const algebra::Vector3D &local,
                                    DerivativeAccumulator &da) {
+  IMPCORE_DEPRECATED_FUNCTION_DEF(2.12, "Updating of derivatives is now handled after evaluation by RigidBody::pull_back_members_adjoints.");
   algebra::Rotation3D rot_local_to_global =
       get_reference_frame().get_transformation_to().get_rotation();
   const algebra::Vector3D deriv_global = rot_local_to_global * deriv_local;
@@ -639,6 +644,7 @@ void RigidBody::add_to_rotational_derivatives(const algebra::Vector4D &other_qde
                                               const algebra::Rotation3D &rot_other_to_local,
                                               const algebra::Rotation3D &rot_local_to_global,
                                               DerivativeAccumulator &da) {
+  IMPCORE_DEPRECATED_FUNCTION_DEF(2.12, "Updating of derivatives is now handled after evaluation by RigidBody::pull_back_members_adjoints.");
   Eigen::MatrixXd derivs =
     algebra::get_jacobian_of_composed_wrt_first(
       rot_local_to_global, rot_other_to_local, false);
@@ -828,10 +834,12 @@ class IMPCOREEXPORT NonRigidMember : public RigidBodyMember {
                                   to global coordinates.
       @param da               Accumulates the output derivatives.
    */
+  IMPCORE_DEPRECATED_METHOD_DECL(2.12)
   void add_to_internal_rotational_derivatives(const algebra::Vector4D &local_qderiv,
                                               const algebra::Rotation3D &rot_local_to_parent,
                                               const algebra::Rotation3D &rot_parent_to_global,
                                               DerivativeAccumulator &da) {
+    IMPCORE_DEPRECATED_FUNCTION_DEF(2.12, "Updating of derivatives is now handled after evaluation by RigidBody::pull_back_members_adjoints.");
     Eigen::MatrixXd derivs =
       algebra::get_jacobian_of_composed_wrt_second(
         rot_parent_to_global, rot_local_to_parent, false);

--- a/modules/core/include/rigid_bodies.h
+++ b/modules/core/include/rigid_bodies.h
@@ -102,10 +102,6 @@ class IMPCOREEXPORT RigidBody : public XYZ {
 
   static ObjectKey get_constraint_key_1();
 
-  static FloatKeys get_rotation_keys() {
-    return internal::rigid_body_data().quaternion_;
-  }
-
   // setup rigid body attributes with particles in ps, using their
   // center of mass, inertia tensor  to initialize the reference frame
   static void do_setup_particle(Model *m, ParticleIndex pi,
@@ -126,6 +122,11 @@ class IMPCOREEXPORT RigidBody : public XYZ {
 
  public:
   RigidMembers get_rigid_members() const;
+
+  //! Get keys for rotation quaternion.
+  static FloatKeys get_rotation_keys() {
+    return internal::rigid_body_data().quaternion_;
+  }
 
   //! Returns a list of all members that are not themselves decorated as
   //! rigid bodies, in the form of particle indexes.

--- a/modules/core/include/rigid_bodies.h
+++ b/modules/core/include/rigid_bodies.h
@@ -527,7 +527,7 @@ void RigidBody::add_to_derivatives(const algebra::Vector3D &deriv_local,
 
   Eigen::RowVector4d q =
     Eigen::RowVector3d(deriv_global.get_data()) *
-    rot_local_to_global.get_gradient(Eigen::Vector3d(local.get_data()));
+    rot_local_to_global.get_gradient(Eigen::Vector3d(local.get_data()), false);
 
   for (unsigned int i = 0; i < 4; ++i) {
     get_model()->add_to_derivative(internal::rigid_body_data().quaternion_[i],
@@ -555,7 +555,7 @@ void RigidBody::add_to_rotational_derivatives(const algebra::Vector4D &other_qde
                                               DerivativeAccumulator &da) {
   Eigen::MatrixXd derivs =
     algebra::get_gradient_of_composed_with_respect_to_first(
-      rot_local_to_global, rot_other_to_local);
+      rot_local_to_global, rot_other_to_local, false);
   Eigen::RowVector4d qderiv = Eigen::RowVector4d(other_qderiv.get_data()) * derivs;
   for (unsigned int i = 0; i < 4; ++i) {
     get_model()->add_to_derivative(internal::rigid_body_data().quaternion_[i],
@@ -748,7 +748,7 @@ class IMPCOREEXPORT NonRigidMember : public RigidBodyMember {
                                               DerivativeAccumulator &da) {
     Eigen::MatrixXd derivs =
       algebra::get_gradient_of_composed_with_respect_to_second(
-        rot_parent_to_global, rot_local_to_parent);
+        rot_parent_to_global, rot_local_to_parent, false);
     Eigen::RowVector4d qderiv = Eigen::RowVector4d(local_qderiv.get_data()) * derivs;
     for (unsigned int i = 0; i < 4; ++i) {
       get_model()->add_to_derivative(get_internal_rotation_keys()[i],

--- a/modules/core/src/rigid_bodies.cpp
+++ b/modules/core/src/rigid_bodies.cpp
@@ -249,7 +249,7 @@ void AccumulateRigidBodyDerivatives::apply_index(
       algebra::Vector3D dv = d.get_derivatives();
       v += dv;
       // IMP_LOG_TERSE( "Adding " << dv << " to derivative" << std::endl);
-      q += rot.get_gradient(Eigen::Vector3d(
+      q += rot.get_jacobian_of_rotated(Eigen::Vector3d(
         d.get_internal_coordinates().get_data()), false).transpose() *
         Eigen::Vector3d(dv.get_data());
 
@@ -257,7 +257,7 @@ void AccumulateRigidBodyDerivatives::apply_index(
         algebra::Rotation3D mrot = RigidBodyMember(d).get_internal_transformation().get_rotation();
         Eigen::Vector4d mq(RigidBody(d).get_rotational_derivatives().get_data());
         Eigen::MatrixXd dq =
-          algebra::get_gradient_of_composed_with_respect_to_first(rot, mrot, false).transpose();
+          algebra::get_jacobian_of_composed_wrt_first(rot, mrot, false).transpose();
         q += dq * mq;
       }
     }

--- a/modules/core/src/rigid_bodies.cpp
+++ b/modules/core/src/rigid_bodies.cpp
@@ -277,10 +277,10 @@ void AccumulateRigidBodyDerivatives::apply_index(
                                     internal::rigid_body_data().quaternion_[1])
                              << " "
                              << rb.get_particle()->get_derivative(
-                                    internal::rigid_body_data().quaternion_[1])
+                                    internal::rigid_body_data().quaternion_[2])
                              << " "
                              << rb.get_particle()->get_derivative(
-                                    internal::rigid_body_data().quaternion_[2])
+                                    internal::rigid_body_data().quaternion_[3])
                              << ": " << q);
     }
 #if IMP_HAS_CHECKS >= IMP_INTERNAL

--- a/modules/core/src/rigid_bodies.cpp
+++ b/modules/core/src/rigid_bodies.cpp
@@ -250,14 +250,14 @@ void AccumulateRigidBodyDerivatives::apply_index(
       v += dv;
       // IMP_LOG_TERSE( "Adding " << dv << " to derivative" << std::endl);
       q += rot.get_gradient(Eigen::Vector3d(
-        d.get_internal_coordinates().get_data())).transpose() *
+        d.get_internal_coordinates().get_data()), false).transpose() *
         Eigen::Vector3d(dv.get_data());
 
       if (RigidBody::get_is_setup(d)) {
         algebra::Rotation3D mrot = RigidBodyMember(d).get_internal_transformation().get_rotation();
         Eigen::Vector4d mq(RigidBody(d).get_rotational_derivatives().get_data());
         Eigen::MatrixXd dq =
-          algebra::get_gradient_of_composed_with_respect_to_first(rot, mrot).transpose();
+          algebra::get_gradient_of_composed_with_respect_to_first(rot, mrot, false).transpose();
         q += dq * mq;
       }
     }

--- a/modules/core/test/standards_exceptions
+++ b/modules/core/test/standards_exceptions
@@ -1,10 +1,16 @@
 value_object_exceptions=['HierarchyVisitor', 'ModifierVisitor']
 
 function_name_exceptions=['RigidBody.normalize_rotation',
+        'RigidBody.pull_back_body_member_adjoints',
+        'RigidBody.pull_back_member_adjoints',
+        'RigidBody.pull_back_members_adjoints',
         'transform',
         'ExperimentalTree.connect',
         'ExperimentalTree.finalize',
         'Gaussian.normalize_rotation',
+        'Gaussian.pull_back_body_member_adjoints',
+        'Gaussian.pull_back_member_adjoints',
+        'Gaussian.pull_back_members_adjoints',
         'assign_blame',
         'Surface.reflect',
         'Direction.reflect',

--- a/modules/core/test/test_nested_rigid_bodies.py
+++ b/modules/core/test/test_nested_rigid_bodies.py
@@ -229,7 +229,7 @@ class Tests(IMP.test.TestCase):
         exp_lqderv = IMP.algebra.Vector4D()
         for i in range(4):
             exp_lqderv[i] = (
-                lderv * rot_local_to_parent.get_derivative(lcoord, i))
+                lderv * rot_local_to_parent.get_derivative(lcoord, i, False))
 
         lqderv = IMP.core.NonRigidMember(
             nrb).get_internal_rotational_derivatives()
@@ -273,9 +273,7 @@ class Tests(IMP.test.TestCase):
             delta=1e-6
         )
 
-        q = rb.get_rotation().get_quaternion()
-        projection_matrix = np.eye(4) - np.outer(q, q)
-        exp_deriv = np.dot(projection_matrix, -kappa * mu)
+        exp_deriv = -kappa * mu
 
         # ensure that derivative is propagated correctly
         self.assertSequenceAlmostEqual(


### PR DESCRIPTION
This PR makes several significant changes to rigid body derivatives in IMP:
- Fix to quaternion derivatives. Previously, local and global quaternion derivatives were always projected to the hyperplane tangent to the 3-sphere at the unit quaternion during back-propagation. This corresponds to the first step of the scoring function evaluation being a normalization operation (it is the Jacobian of l2-normalization). Importantly, this gradient corresponds to a different log density than we have written down. It's neither with respect to the spherical measure of unit quaternions nor the measure in unconstrained quaternion space. Because the derivatives are accumulated from the innermost member in a hierarchy of nested rigid bodies to the outermost, none of the above gradients were guaranteed to be correct. Since the quaternion derivatives were implemented by me for https://github.com/salilab/imp/issues/790 and [HMC](https://github.com/salilab/hmc) with potentially nested rigid bodies, this behavior probably didn't manifest for anyone else.
- General purpose functions for pulling back adjoints on operations with transformations and rotations. This is motivated by the observation that IMP uses reverse-mode differentiation (gradients are computed from the scoring function backwards). In reverse-mode, derivatives on intermediates are called adjoints, and they can be pulled back to earlier intermediates and ultimately variables with vector-Jacobian products, although adjoint functions such the ones implemented here are usually more efficient.
- Reimplementation of pullback of rigid body adjoints, ultimately to gradients, using the above
- Improved testing of rigid body derivatives. All gradients on nested rigid bodies with a mixture of rigid and non-rigid members are now compared with central difference approximations of the same.
- Several minor fixes to documentation/logging.

If you're not using quaternion derivatives or nested rigid bodies, you shouldn't notice any difference. However, it would be nice if some of the Brownian dynamics folks (e.g. @barakr) could make sure that the torques are still as expected. These don't seem to be tested well in `IMP::core`.

Since HMC will permit any Float variable with gradients to be sampled, there's more impetus to make sure gradients are handled correctly in IMP and easier to implement for complicated restraints/forward models/representations, like those used for EM. Perhaps an entry in the manual would be helpful. I'm volunteering but would appreciate suggestions; the rigid body example seems a bit too complex for such a write-up.