### PR TITLE
Improvements to Weight

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,15 @@ ChangeLog {#changelog}
 - The `rg` tool (part of the IMP::saxs module, used to compute radius of
   gyration from a SAXS profile) is now called `compute_rg` for consistency
   with other SAXS tools and to avoid conflicts with other packages.
+- IMP::isd::Weight is now constrained to the unit simplex, and methods were
+  added for adding to its derivatives. IMP::isd::Weight::do_setup_particle()
+  for no arguments is now deprecated, along with
+  IMP::isd::Weight::add_weight(). In the future, IMP::isd::Weight will be
+  set up with a fixed number of weights.
+  IMP::isd::Weight::get_number_of_states() and
+  IMP::isd::Weight::get_nstates_key() were deprecated and superseded by
+  IMP::isd::Weight::get_number_of_weights() and
+  IMP::isd::Weight::get_number_of_weights_key(), respectively.
 
 # 2.11.1 - 2019-07-18 # {#changelog_2_11_1}
 - Bugfix: fix build system failures with CMake 3.12 and 3.13, and on Windows.

--- a/modules/isd/include/Weight.h
+++ b/modules/isd/include/Weight.h
@@ -42,8 +42,15 @@ class IMPISDEXPORT Weight : public Decorator {
 
  public:
   IMP_DECORATOR_METHODS(Weight, Decorator);
+  //! Set up an empty Weight.
+  /** \deprecated_at{2.12}. Use the versions with a fixed number of weights.*/
   IMP_DECORATOR_SETUP_0(Weight);
+
+  //! Set up Weight with a fixed number of weights.
+  /** All weights are initialized with the same value. */
   IMP_DECORATOR_SETUP_1(Weight, Int, nweights);
+
+  //! Set up Weight from the provided weight vector.
   IMP_DECORATOR_SETUP_1(Weight, const algebra::VectorKD&, w);
 
   IMPISD_DEPRECATED_METHOD_DECL(2.12)
@@ -70,7 +77,11 @@ class IMPISDEXPORT Weight : public Decorator {
   void set_weights_lazy(const algebra::VectorKD& w);
 
   //! Set all weights, enforcing the simplex constraint
-  /** Any negative weights are set to 0, and the unit l1-norm is enforced.*/
+  /** Any negative weights are set to 0, and the unit l1-norm is enforced. The
+      algorithm used to project to the simplex is described in
+      arXiv:1309.1541. It finds a threshold below which all weights are set to
+      0 and above which all weights shifted by the threshold sum to 1.
+  */
   void set_weights(const algebra::VectorKD& w);
 
   //! Set weights are optimized

--- a/modules/isd/include/Weight.h
+++ b/modules/isd/include/Weight.h
@@ -1,6 +1,6 @@
 /**
  *  \file IMP/isd/Weight.h
- *  \brief Add weights for a set of states to a particle.
+ *  \brief Add weights constrained to the unit simplex to a particle.
  *
  *  Copyright 2007-2019 IMP Inventors. All rights reserved.
  *
@@ -10,56 +10,120 @@
 #define IMPISD_WEIGHT_H
 
 #include "isd_config.h"
-
 #include <IMP/Particle.h>
 #include <IMP/decorator_macros.h>
 #include <IMP/Model.h>
 #include <IMP/Decorator.h>
-#include <IMP/exception.h>
-#include <sstream>
 
 IMPISD_BEGIN_NAMESPACE
 
-//! Add weights for a set of states to a particle.
+static const int IMPISD_MAX_WEIGHTS = 20;
+
+//! Add weights to a particle.
+/** Weights are constrained to the unit simplex. That is, each weight is
+    constrained to be positive, and the sum of all of the weights is
+    constrained to be 1.
+
+    \ingroup decorators
+*/
 class IMPISDEXPORT Weight : public Decorator {
 
-  static const int nstates_max = 20;
+  IMPISD_DEPRECATED_METHOD_DECL(2.12)
   static void do_setup_particle(Model *m, ParticleIndex pi);
+
+  static void do_setup_particle(Model *m, ParticleIndex pi, Int dim);
+
+  static void do_setup_particle(Model *m, ParticleIndex pi,
+                                const algebra::VectorKD& w);
+
+  static void add_constraint(Model *m, ParticleIndex pi);
+
+  static ObjectKey get_constraint_key();
 
  public:
   IMP_DECORATOR_METHODS(Weight, Decorator);
   IMP_DECORATOR_SETUP_0(Weight);
+  IMP_DECORATOR_SETUP_1(Weight, Int, dim);
+  IMP_DECORATOR_SETUP_1(Weight, const algebra::VectorKD&, w);
 
-  //! Get number of states key
+  IMPISD_DEPRECATED_METHOD_DECL(2.12)
   static IntKey get_nstates_key();
 
-  //! Get i-th weight key
+  //! Get number of weights key
+  static IntKey get_dimension_key();
+
+  //! Get ith weight key
   static FloatKey get_weight_key(int i);
 
+  //! Get the ith weight
+  Float get_weight(int i) const;
+
+  //! Get all weights
+  algebra::VectorKD get_weights() const;
+
+  //! Set the ith weight lazily.
+  /** Delay enforcing the simplex constraint until Model::update(). */
+  void set_weight_lazy(int i, Float wi);
+
   //! Set all the weights
-  void set_weights(algebra::VectorKD w);
+  /** Delay enforcing the simplex constraint until Model::update(). */
+  void set_weights_lazy(const algebra::VectorKD& w);
 
-  //! Add one weight
-  void add_weight();
-
-  //! Get the i-th weight
-  Float get_weight(int i);
-
-  //! Get all the weights
-  algebra::VectorKD get_weights();
+  //! Set all weights, enforcing the simplex constraint
+  /** Any negative weights are set to 0, and the unit l1-norm is enforced.*/
+  void set_weights(const algebra::VectorKD& w);
 
   //! Set weights are optimized
   void set_weights_are_optimized(bool tf);
 
-  //! Get number of states
-  Int get_number_of_states();
+  //! Get derivative wrt ith weight.
+  Float get_weight_derivative(int i) const;
 
-  static bool get_is_setup(Model *m, ParticleIndex pi) {
-    return m->get_has_attribute(get_nstates_key(), pi);
-  }
+  //! Get derivatives wrt all weights.
+  algebra::VectorKD get_weights_derivatives() const;
+
+  //! Add to derivative wrt ith weight.
+  void add_to_weight_derivative(int i, Float dwi,
+                                const DerivativeAccumulator &da);
+
+  //! Add to derivatives wrt all weights.
+  void add_to_weights_derivatives(const algebra::VectorKD& dw,
+                                  const DerivativeAccumulator &da);
+
+  IMPISD_DEPRECATED_METHOD_DECL(2.12)
+  void add_weight();
+
+  IMPISD_DEPRECATED_METHOD_DECL(2.12)
+  Int get_number_of_states() const;
+
+  //! Get number of weights.
+  Int get_dimension() const;
+
+  static bool get_is_setup(Model *m, ParticleIndex pi);
 };
 
-IMP_VALUES(Weight, Weights);
+IMP_DECORATORS(Weight, Weights, Decorators);
+
+
+#if !defined(IMP_DOXYGEN) && !defined(SWIG)
+class IMPCOREEXPORT WeightSimplexConstraint : public IMP::Constraint {
+  private:
+    ParticleIndex pi_;
+
+  private:
+    WeightSimplexConstraint(Particle *p)
+        : IMP::Constraint(p->get_model(), "WeightSimplexConstraint%1%")
+        , pi_(p->get_index()) {}
+
+  public:
+    friend class Weight;
+    virtual void do_update_attributes() IMP_OVERRIDE;
+    virtual void do_update_derivatives(DerivativeAccumulator *da) IMP_OVERRIDE;
+    virtual ModelObjectsTemp do_get_inputs() const IMP_OVERRIDE;
+    virtual ModelObjectsTemp do_get_outputs() const IMP_OVERRIDE;
+    IMP_OBJECT_METHODS(WeightSimplexConstraint);
+};
+#endif
 
 IMPISD_END_NAMESPACE
 

--- a/modules/isd/include/Weight.h
+++ b/modules/isd/include/Weight.h
@@ -31,7 +31,7 @@ class IMPISDEXPORT Weight : public Decorator {
   IMPISD_DEPRECATED_METHOD_DECL(2.12)
   static void do_setup_particle(Model *m, ParticleIndex pi);
 
-  static void do_setup_particle(Model *m, ParticleIndex pi, Int dim);
+  static void do_setup_particle(Model *m, ParticleIndex pi, Int nweights);
 
   static void do_setup_particle(Model *m, ParticleIndex pi,
                                 const algebra::VectorKD& w);
@@ -43,7 +43,7 @@ class IMPISDEXPORT Weight : public Decorator {
  public:
   IMP_DECORATOR_METHODS(Weight, Decorator);
   IMP_DECORATOR_SETUP_0(Weight);
-  IMP_DECORATOR_SETUP_1(Weight, Int, dim);
+  IMP_DECORATOR_SETUP_1(Weight, Int, nweights);
   IMP_DECORATOR_SETUP_1(Weight, const algebra::VectorKD&, w);
 
   IMPISD_DEPRECATED_METHOD_DECL(2.12)

--- a/modules/isd/include/Weight.h
+++ b/modules/isd/include/Weight.h
@@ -50,7 +50,7 @@ class IMPISDEXPORT Weight : public Decorator {
   static IntKey get_nstates_key();
 
   //! Get number of weights key
-  static IntKey get_dimension_key();
+  static IntKey get_number_of_weights_key();
 
   //! Get ith weight key
   static FloatKey get_weight_key(int i);
@@ -97,7 +97,7 @@ class IMPISDEXPORT Weight : public Decorator {
   Int get_number_of_states() const;
 
   //! Get number of weights.
-  Int get_dimension() const;
+  Int get_number_of_weights() const;
 
   static bool get_is_setup(Model *m, ParticleIndex pi);
 };

--- a/modules/isd/src/CysteineCrossLinkRestraint.cpp
+++ b/modules/isd/src/CysteineCrossLinkRestraint.cpp
@@ -66,7 +66,7 @@ void CysteineCrossLinkRestraint::add_contribution(ParticleIndexAdaptor p1,
   Model *m = get_model();
   ps1_.push_back(p1);
   ps2_.push_back(p2);
-  if (Weight(m, weight_).get_number_of_states() <
+  if (Weight(m, weight_).get_dimension() <
       static_cast<int>(get_number_of_contributions())) {
     Weight(m, weight_).add_weight();
   }
@@ -85,7 +85,7 @@ void CysteineCrossLinkRestraint::add_contribution(ParticleIndexes p1,
   pslist1_.push_back(p1);
   pslist2_.push_back(p2);
   Model *m = get_model();
-  if (Weight(m, weight_).get_number_of_states() <
+  if (Weight(m, weight_).get_dimension() <
       static_cast<int>(get_number_of_contributions())) {
     Weight(m, weight_).add_weight();
   }
@@ -187,9 +187,14 @@ Floats CysteineCrossLinkRestraint::get_frequencies() const {
 
   Floats frequencies;
 
+  Weight w(m, weight_);
+  IMP_INTERNAL_CHECK(
+    get_number_of_contributions() == w.get_dimension(),
+    "Number of contributions does not equal weights dimension."
+  );
   for (unsigned i = 0; i < get_number_of_contributions(); ++i) {
 
-    double ww = Weight(m, weight_).get_weight(i);
+    double ww = w.get_weight(i);
 
     double fi = (1.0 - pow(epsilon, nus[i] / numax)) * ww;
     frequencies.push_back(fi);

--- a/modules/isd/src/CysteineCrossLinkRestraint.cpp
+++ b/modules/isd/src/CysteineCrossLinkRestraint.cpp
@@ -66,7 +66,7 @@ void CysteineCrossLinkRestraint::add_contribution(ParticleIndexAdaptor p1,
   Model *m = get_model();
   ps1_.push_back(p1);
   ps2_.push_back(p2);
-  if (Weight(m, weight_).get_dimension() <
+  if (Weight(m, weight_).get_number_of_weights() <
       static_cast<int>(get_number_of_contributions())) {
     Weight(m, weight_).add_weight();
   }
@@ -85,7 +85,7 @@ void CysteineCrossLinkRestraint::add_contribution(ParticleIndexes p1,
   pslist1_.push_back(p1);
   pslist2_.push_back(p2);
   Model *m = get_model();
-  if (Weight(m, weight_).get_dimension() <
+  if (Weight(m, weight_).get_number_of_weights() <
       static_cast<int>(get_number_of_contributions())) {
     Weight(m, weight_).add_weight();
   }
@@ -189,7 +189,7 @@ Floats CysteineCrossLinkRestraint::get_frequencies() const {
 
   Weight w(m, weight_);
   IMP_INTERNAL_CHECK(
-    get_number_of_contributions() == w.get_dimension(),
+    get_number_of_contributions() == w.get_number_of_weights(),
     "Number of contributions does not equal weights dimension."
   );
   for (unsigned i = 0; i < get_number_of_contributions(); ++i) {

--- a/modules/isd/src/Weight.cpp
+++ b/modules/isd/src/Weight.cpp
@@ -1,31 +1,87 @@
 /**
  *  \file isd/Weight.cpp
- *  \brief Add a name to a particle.
+ *  \brief Add weights constrained to the unit simplex to a particle.
  *
  *  Copyright 2007-2019 IMP Inventors. All rights reserved.
  *
  */
 
 #include <IMP/isd/Weight.h>
+#include <IMP/exception.h>
+#include <limits.h>
+#include <sstream>
 
 IMPISD_BEGIN_NAMESPACE
 
 void Weight::do_setup_particle(Model *m, ParticleIndex pi) {
-  m->add_attribute(get_nstates_key(), pi, 0);
-  for (int i = 0; i < nstates_max; ++i) {
-    m->add_attribute(get_weight_key(i), pi, 0.0);
-  }
+  IMPISD_DEPRECATED_METHOD_DEF(
+    2.12,
+    "Use do_setup_particle(m, pi, dim) or do_setup_particle(m, pi, w) instead."
+  );
+
+  m->add_attribute(get_dimension_key(), pi, 0);
+
+  add_constraint(m, pi);
+}
+
+void Weight::do_setup_particle(Model *m, ParticleIndex pi, Int dim) {
+  IMP_USAGE_CHECK(dim > 0, "Number of weights must be greater than zero.");
+  m->add_attribute(get_dimension_key(), pi, dim);
+
+  Float wi = 1.0 / static_cast<Float>(dim);
+  for (int i = 0; i < dim; ++i)
+    m->add_attribute(get_weight_key(i), pi, wi);
+
+  add_constraint(m, pi);
+}
+
+void Weight::do_setup_particle(Model *m, ParticleIndex pi,
+                               const algebra::VectorKD &w) {
+  Int dim = w.get_dimension();
+  IMP_USAGE_CHECK(dim > 0, "Number of weights must be greater than zero.");
+  m->add_attribute(get_dimension_key(), pi, dim);
+
+  m->add_attribute(get_weight_key(0), pi, w[0]);
+  for (int i = 1; i < dim; ++i)
+    m->add_attribute(get_weight_key(i), pi, w[i]);
+
+  add_constraint(m, pi);
+
+  Weight pw(m, pi);
+  pw.set_weights(pw.get_weights());
+}
+
+void Weight::add_constraint(Model *m, ParticleIndex pi) {
+  ObjectKey k(get_constraint_key());
+  Pointer<WeightSimplexConstraint> c(new WeightSimplexConstraint(
+    m->get_particle(pi)));
+  c->set_was_used(true);
+  m->get_particle(pi)->add_attribute(k, c);
+  m->add_score_state(c);
+}
+
+bool Weight::get_is_setup(Model *m, ParticleIndex pi) {
+  if (!m->get_has_attribute(get_dimension_key(), pi)) return false;
+  if (!m->get_has_attribute(get_constraint_key(), pi)) return false;
+  Int dim = m->get_attribute(get_dimension_key(), pi);
+  for (unsigned int i = 0; i < dim; ++i)
+    if (!m->get_has_attribute(get_weight_key(i), pi)) return false;
+  return true;
 }
 
 IntKey Weight::get_nstates_key() {
-  static IntKey k("nstates");
+  return get_dimension_key();
+}
+
+IntKey Weight::get_dimension_key() {
+  static IntKey k("nweights");
   return k;
 }
 
 FloatKey Weight::get_weight_key(int j) {
   static FloatKeys kk;
   if (kk.empty()) {
-    for (int i = 0; i < nstates_max; ++i) {
+    for (int i = 0; i < IMPISD_MAX_WEIGHTS; ++i) {
       std::stringstream out;
       out << i;
       kk.push_back(FloatKey("weight" + out.str()));
@@ -34,53 +90,181 @@ FloatKey Weight::get_weight_key(int j) {
   return kk[j];
 }
 
-//! Set all the weights
-void Weight::set_weights(algebra::VectorKD w) {
-  IMP_USAGE_CHECK(static_cast<int>(w.get_dimension()) == get_number_of_states(),
-                  "Out of range");
-  for (int i = 0; i < get_number_of_states(); ++i) {
-    get_particle()->set_value(get_weight_key(i), w[i]);
-  }
+ObjectKey Weight::get_constraint_key() {
+  static ObjectKey k("weight_const");
+  return k;
 }
 
-//! Add one weight
-void Weight::add_weight() {
-  int i = get_particle()->get_value(get_nstates_key());
-  IMP_USAGE_CHECK(i < nstates_max, "Out of range");
-  get_particle()->set_value(get_nstates_key(), i + 1);
-  Float w = 1.0 / static_cast<Float>(get_number_of_states());
-  for (int i = 0; i < get_number_of_states(); ++i) {
-    get_particle()->set_value(get_weight_key(i), w);
-  }
-}
-
-//! Get the i-th weight
-Float Weight::get_weight(int i) {
-  IMP_USAGE_CHECK(i < get_number_of_states(), "Out of range");
+Float Weight::get_weight(int i) const {
+  IMP_USAGE_CHECK(i < get_dimension(), "Out of range");
   return get_particle()->get_value(get_weight_key(i));
 }
 
-//! Get all weights
-algebra::VectorKD Weight::get_weights() {
-  algebra::VectorKD ww = algebra::get_zero_vector_kd(get_number_of_states());
-  for (int i = 0; i < get_number_of_states(); ++i) {
-    ww[i] = get_weight(i);
-  }
-  return ww;
+algebra::VectorKD Weight::get_weights() const {
+  Int dim = get_dimension();
+  algebra::VectorKD w = algebra::get_zero_vector_kd(dim);
+  for (int i = 0; i < dim; ++i)
+    w[i] = get_particle()->get_value(get_weight_key(i));
+  return w;
 }
 
-//! Set weights are optimized
+void Weight::set_weight_lazy(int i, Float wi) {
+  IMP_USAGE_CHECK(static_cast<int>(i) < get_dimension(),
+                  "Out of range");
+  get_particle()->set_value(get_weight_key(i), wi);
+}
+
+void Weight::set_weights_lazy(const algebra::VectorKD& w) {
+  Int dim = w.get_dimension();
+  IMP_USAGE_CHECK(static_cast<int>(dim) == get_dimension(),
+                  "Out of range");
+  for (unsigned int i = 0; i < dim; ++i)
+    get_particle()->set_value(get_weight_key(i), w[i]);
+}
+
+void Weight::set_weights(const algebra::VectorKD& w) {
+  Int dim = w.get_dimension();
+  IMP_USAGE_CHECK(static_cast<int>(dim) == get_dimension(),
+                  "Out of range");
+
+  bool project = false;
+  Float wsum = 0.0;
+  for (unsigned int i = 0; i < dim; ++i) {
+    if (w[i] < 0) {
+      project = true;
+      break;
+    }
+    wsum += w[i];
+    if (wsum > 1) {
+      project = true;
+      break;
+    }
+  }
+
+  if (!project) {
+    if (std::abs(wsum - 1.0) < std::numeric_limits<double>::epsilon()) {
+      for (unsigned int i = 0; i < dim; ++i)
+        get_particle()->set_value(get_weight_key(i), w[i]);
+      return;
+    } else if (wsum == 0.0) {
+      Float wi = 1.0 / static_cast<Float>(dim);
+      for (unsigned int i = 0; i < dim; ++i)
+        get_particle()->set_value(get_weight_key(i), wi);
+      return;
+    }
+  }
+
+  // Weights are not on the simplex.
+  // Perform O(n log(n)) Euclidean projection from arxiv:1309.1541.
+  IMP_LOG_VERBOSE("Weight particle " << get_particle()->get_name()
+                                     << " has weights " << w
+                                     << " with l1 norm " << get_l1_norm(w)
+                                     << " and will be projected");
+
+  Floats u(dim);
+  std::copy(w.begin(), w.end(), u.begin());
+  std::sort(u.begin(), u.end(), std::greater<double>());
+  
+  Floats u_cumsum(dim);
+  Float usum = 0.0;
+  for (unsigned int i = 0; i < dim; ++i) {
+    usum += u[i];
+    u_cumsum[i] = usum;
+  }
+  int rho = 1;
+  while (rho < dim) {
+    if (u[rho] + (1 - u_cumsum[rho]) / (rho + 1) < 0)
+      break;
+    rho += 1;
+  }
+  Float lam = (1 - u_cumsum[rho - 1]) / rho;
+
+  for (unsigned int i = 0; i < dim; ++i) {
+    Float wi = w[i] + lam;
+    get_particle()->set_value(get_weight_key(i), wi > 0 ? wi : 0.0);
+  }
+}
+
 void Weight::set_weights_are_optimized(bool tf) {
-  for (int i = 0; i < nstates_max; ++i) {
+  for (unsigned int i = 0; i < get_dimension(); ++i)
     get_particle()->set_is_optimized(get_weight_key(i), tf);
-  }
 }
 
-//! Get number of states
-Int Weight::get_number_of_states() {
-  return get_particle()->get_value(get_nstates_key());
+Float Weight::get_weight_derivative(int i) const {
+  int dim = get_dimension();
+  IMP_USAGE_CHECK(i < dim, "Out of bounds.");
+  return get_particle()->get_derivative(get_weight_key(i));
 }
 
-void Weight::show(std::ostream &out) const { out << "Weight "; }
+algebra::VectorKD Weight::get_weights_derivatives() const {
+  int dim = get_dimension();
+  algebra::VectorKD dw = algebra::get_zero_vector_kd(dim);
+  for (int i = 0; i < dim; ++i)
+    dw[i] = get_particle()->get_derivative(get_weight_key(i));
+  return dw;
+}
+
+void Weight::add_to_weight_derivative(int i, Float dwi,
+                                      const DerivativeAccumulator &da) {
+  int dim = get_dimension();
+  IMP_USAGE_CHECK(i < dim, "Out of bounds.");
+  get_particle()->add_to_derivative(get_weight_key(i), dwi, da);
+}
+
+void Weight::add_to_weights_derivatives(const algebra::VectorKD& dw,
+                                        const DerivativeAccumulator &da) {
+  int dim = dw.get_dimension();
+  IMP_USAGE_CHECK(static_cast<int>(dim) == get_dimension(),
+                  "Out of range");
+  for (unsigned int i = 0; i < dim; ++i)
+    get_particle()->add_to_derivative(get_weight_key(i), dw[i], da);
+}
+
+void Weight::add_weight() {
+  IMPISD_DEPRECATED_METHOD_DEF(
+    2.12,
+    "Set up the Weight with a fixed dimension instead."
+  );
+  Int dim = get_dimension() + 1;
+  IMP_USAGE_CHECK(dim <= IMPISD_MAX_WEIGHTS, "Out of range");
+  get_particle()->set_value(get_dimension_key(), dim);
+  Float w = 1.0 / static_cast<Float>(dim);
+  for (int i = 0; i < dim; ++i)
+    get_particle()->set_value(get_weight_key(i), w);
+}
+
+Int Weight::get_number_of_states() const {
+  IMPISD_DEPRECATED_METHOD_DEF(
+    2.12,
+    "Use get_dimension() instead."
+  );
+  return get_dimension();
+}
+
+Int Weight::get_dimension() const {
+  return get_particle()->get_value(get_dimension_key());
+}
+
+void Weight::show(std::ostream &out) const {
+  out << "Weight: " << get_weights();
+}
+
+
+
+void WeightSimplexConstraint::do_update_attributes() {
+  Weight w(get_model(), pi_);
+  w.set_weights(w.get_weights());
+}
+
+void WeightSimplexConstraint::do_update_derivatives(
+  DerivativeAccumulator *da) {}
+
+ModelObjectsTemp WeightSimplexConstraint::do_get_inputs() const {
+  return ModelObjectsTemp(1, get_model()->get_particle(pi_));
+}
+
+ModelObjectsTemp WeightSimplexConstraint::do_get_outputs() const {
+  return ModelObjectsTemp(1, get_model()->get_particle(pi_));
+}
 
 IMPISD_END_NAMESPACE

--- a/modules/isd/src/Weight.cpp
+++ b/modules/isd/src/Weight.cpp
@@ -19,14 +19,14 @@ void Weight::do_setup_particle(Model *m, ParticleIndex pi) {
     "Use do_setup_particle(m, pi, dim) or do_setup_particle(m, pi, w) instead."
   );
 
-  m->add_attribute(get_dimension_key(), pi, 0);
+  m->add_attribute(get_number_of_weights_key(), pi, 0);
 
   add_constraint(m, pi);
 }
 
 void Weight::do_setup_particle(Model *m, ParticleIndex pi, Int dim) {
   IMP_USAGE_CHECK(dim > 0, "Number of weights must be greater than zero.");
-  m->add_attribute(get_dimension_key(), pi, dim);
+  m->add_attribute(get_number_of_weights_key(), pi, dim);
 
   Float wi = 1.0 / static_cast<Float>(dim);
   for (int i = 0; i < dim; ++i)
@@ -39,7 +39,7 @@ void Weight::do_setup_particle(Model *m, ParticleIndex pi,
                                const algebra::VectorKD &w) {
   Int dim = w.get_dimension();
   IMP_USAGE_CHECK(dim > 0, "Number of weights must be greater than zero.");
-  m->add_attribute(get_dimension_key(), pi, dim);
+  m->add_attribute(get_number_of_weights_key(), pi, dim);
 
   m->add_attribute(get_weight_key(0), pi, w[0]);
   for (int i = 1; i < dim; ++i)
@@ -61,19 +61,19 @@ void Weight::add_constraint(Model *m, ParticleIndex pi) {
 }
 
 bool Weight::get_is_setup(Model *m, ParticleIndex pi) {
-  if (!m->get_has_attribute(get_dimension_key(), pi)) return false;
+  if (!m->get_has_attribute(get_number_of_weights_key(), pi)) return false;
   if (!m->get_has_attribute(get_constraint_key(), pi)) return false;
-  Int dim = m->get_attribute(get_dimension_key(), pi);
+  Int dim = m->get_attribute(get_number_of_weights_key(), pi);
   for (unsigned int i = 0; i < dim; ++i)
     if (!m->get_has_attribute(get_weight_key(i), pi)) return false;
   return true;
 }
 
 IntKey Weight::get_nstates_key() {
-  return get_dimension_key();
+  return get_number_of_weights_key();
 }
 
-IntKey Weight::get_dimension_key() {
+IntKey Weight::get_number_of_weights_key() {
   static IntKey k("nweights");
   return k;
 }
@@ -96,12 +96,12 @@ ObjectKey Weight::get_constraint_key() {
 }
 
 Float Weight::get_weight(int i) const {
-  IMP_USAGE_CHECK(i < get_dimension(), "Out of range");
+  IMP_USAGE_CHECK(i < get_number_of_weights(), "Out of range");
   return get_particle()->get_value(get_weight_key(i));
 }
 
 algebra::VectorKD Weight::get_weights() const {
-  Int dim = get_dimension();
+  Int dim = get_number_of_weights();
   algebra::VectorKD w = algebra::get_zero_vector_kd(dim);
   for (int i = 0; i < dim; ++i)
     w[i] = get_particle()->get_value(get_weight_key(i));
@@ -109,14 +109,14 @@ algebra::VectorKD Weight::get_weights() const {
 }
 
 void Weight::set_weight_lazy(int i, Float wi) {
-  IMP_USAGE_CHECK(static_cast<int>(i) < get_dimension(),
+  IMP_USAGE_CHECK(static_cast<int>(i) < get_number_of_weights(),
                   "Out of range");
   get_particle()->set_value(get_weight_key(i), wi);
 }
 
 void Weight::set_weights_lazy(const algebra::VectorKD& w) {
   Int dim = w.get_dimension();
-  IMP_USAGE_CHECK(static_cast<int>(dim) == get_dimension(),
+  IMP_USAGE_CHECK(static_cast<int>(dim) == get_number_of_weights(),
                   "Out of range");
   for (unsigned int i = 0; i < dim; ++i)
     get_particle()->set_value(get_weight_key(i), w[i]);
@@ -124,7 +124,7 @@ void Weight::set_weights_lazy(const algebra::VectorKD& w) {
 
 void Weight::set_weights(const algebra::VectorKD& w) {
   Int dim = w.get_dimension();
-  IMP_USAGE_CHECK(static_cast<int>(dim) == get_dimension(),
+  IMP_USAGE_CHECK(static_cast<int>(dim) == get_number_of_weights(),
                   "Out of range");
 
   bool project = false;
@@ -186,18 +186,18 @@ void Weight::set_weights(const algebra::VectorKD& w) {
 }
 
 void Weight::set_weights_are_optimized(bool tf) {
-  for (unsigned int i = 0; i < get_dimension(); ++i)
+  for (unsigned int i = 0; i < get_number_of_weights(); ++i)
     get_particle()->set_is_optimized(get_weight_key(i), tf);
 }
 
 Float Weight::get_weight_derivative(int i) const {
-  int dim = get_dimension();
+  int dim = get_number_of_weights();
   IMP_USAGE_CHECK(i < dim, "Out of bounds.");
   return get_particle()->get_derivative(get_weight_key(i));
 }
 
 algebra::VectorKD Weight::get_weights_derivatives() const {
-  int dim = get_dimension();
+  int dim = get_number_of_weights();
   algebra::VectorKD dw = algebra::get_zero_vector_kd(dim);
   for (int i = 0; i < dim; ++i)
     dw[i] = get_particle()->get_derivative(get_weight_key(i));
@@ -206,7 +206,7 @@ algebra::VectorKD Weight::get_weights_derivatives() const {
 
 void Weight::add_to_weight_derivative(int i, Float dwi,
                                       const DerivativeAccumulator &da) {
-  int dim = get_dimension();
+  int dim = get_number_of_weights();
   IMP_USAGE_CHECK(i < dim, "Out of bounds.");
   get_particle()->add_to_derivative(get_weight_key(i), dwi, da);
 }
@@ -214,7 +214,7 @@ void Weight::add_to_weight_derivative(int i, Float dwi,
 void Weight::add_to_weights_derivatives(const algebra::VectorKD& dw,
                                         const DerivativeAccumulator &da) {
   int dim = dw.get_dimension();
-  IMP_USAGE_CHECK(static_cast<int>(dim) == get_dimension(),
+  IMP_USAGE_CHECK(static_cast<int>(dim) == get_number_of_weights(),
                   "Out of range");
   for (unsigned int i = 0; i < dim; ++i)
     get_particle()->add_to_derivative(get_weight_key(i), dw[i], da);
@@ -223,11 +223,11 @@ void Weight::add_to_weights_derivatives(const algebra::VectorKD& dw,
 void Weight::add_weight() {
   IMPISD_DEPRECATED_METHOD_DEF(
     2.12,
-    "Set up the Weight with a fixed dimension instead."
+    "Set up the Weight with a fixed number of weights instead."
   );
-  Int dim = get_dimension() + 1;
+  Int dim = get_number_of_weights() + 1;
   IMP_USAGE_CHECK(dim <= IMPISD_MAX_WEIGHTS, "Out of range");
-  get_particle()->set_value(get_dimension_key(), dim);
+  get_particle()->set_value(get_number_of_weights_key(), dim);
   Float w = 1.0 / static_cast<Float>(dim);
   for (int i = 0; i < dim; ++i)
     get_particle()->set_value(get_weight_key(i), w);
@@ -236,13 +236,13 @@ void Weight::add_weight() {
 Int Weight::get_number_of_states() const {
   IMPISD_DEPRECATED_METHOD_DEF(
     2.12,
-    "Use get_dimension() instead."
+    "Use get_number_of_weights() instead."
   );
-  return get_dimension();
+  return get_number_of_weights();
 }
 
-Int Weight::get_dimension() const {
-  return get_particle()->get_value(get_dimension_key());
+Int Weight::get_number_of_weights() const {
+  return get_particle()->get_value(get_number_of_weights_key());
 }
 
 void Weight::show(std::ostream &out) const {

--- a/modules/isd/src/Weight.cpp
+++ b/modules/isd/src/Weight.cpp
@@ -70,6 +70,10 @@ bool Weight::get_is_setup(Model *m, ParticleIndex pi) {
 }
 
 IntKey Weight::get_nstates_key() {
+  IMPISD_DEPRECATED_METHOD_DEF(
+    2.12,
+    "Use get_number_of_weights_key() instead."
+  );
   return get_number_of_weights_key();
 }
 

--- a/modules/isd/src/WeightRestraint.cpp
+++ b/modules/isd/src/WeightRestraint.cpp
@@ -29,18 +29,34 @@ WeightRestraint::WeightRestraint(Particle *w, Float wmin, Float wmax,
 double WeightRestraint::unprotected_evaluate(DerivativeAccumulator *accum)
     const {
   // retrieve weights
-  algebra::VectorKD weight = Weight(w_).get_weights();
+  Weight w(w_);
+  algebra::VectorKD weight = w.get_weights();
+  Int dim = w.get_dimension();
 
   Float dw = 0.;
 
-  for (unsigned i = 0; i < weight.get_dimension(); ++i) {
-    if (weight[i] > wmax_)
-      dw += (weight[i] - wmax_) * (weight[i] - wmax_);
-    else if (weight[i] < wmin_)
-      dw += (wmin_ - weight[i]) * (wmin_ - weight[i]);
-  }
-
   if (accum) {
+    Float deltaw;
+    algebra::VectorKD wderiv = algebra::get_zero_vector_kd(dim);
+    for (unsigned i = 0; i < dim; ++i) {
+      if (weight[i] > wmax_) {
+        deltaw = weight[i] - wmax_;
+        dw += deltaw * deltaw;
+        wderiv[i] = kappa_ * deltaw;
+      } else if (weight[i] < wmin_) {
+        deltaw = wmin_ - weight[i];
+        dw += deltaw * deltaw;
+        wderiv[i] = -kappa_ * deltaw;
+      }
+    }
+    w.add_to_weights_derivatives(wderiv, *accum);
+  } else {
+    for (unsigned i = 0; i < dim; ++i) {
+      if (weight[i] > wmax_)
+        dw += (weight[i] - wmax_) * (weight[i] - wmax_);
+      else if (weight[i] < wmin_)
+        dw += (wmin_ - weight[i]) * (wmin_ - weight[i]);
+    }
   }
 
   return 0.5 * kappa_ * dw;

--- a/modules/isd/src/WeightRestraint.cpp
+++ b/modules/isd/src/WeightRestraint.cpp
@@ -31,7 +31,7 @@ double WeightRestraint::unprotected_evaluate(DerivativeAccumulator *accum)
   // retrieve weights
   Weight w(w_);
   algebra::VectorKD weight = w.get_weights();
-  Int dim = w.get_dimension();
+  Int dim = w.get_number_of_weights();
 
   Float dw = 0.;
 

--- a/modules/isd/test/expensive_test_CysteineCrossLinkRestraint.py
+++ b/modules/isd/test/expensive_test_CysteineCrossLinkRestraint.py
@@ -63,9 +63,9 @@ class TestCysteineCrossLinkRestraint(IMP.test.TestCase):
         nuisance.set_is_optimized(nuisance.get_nuisance_key(), isoptimized)
         return nuisance
 
-    def setup_weight(self, m, isoptimized=True):
+    def setup_weight(self, m, dim, isoptimized=True):
         pw = IMP.Particle(m)
-        weight = IMP.isd.Weight.setup_particle(pw)
+        weight = IMP.isd.Weight.setup_particle(pw, dim)
         weight.set_weights_are_optimized(True)
         return weight
 
@@ -135,7 +135,7 @@ class TestCysteineCrossLinkRestraint(IMP.test.TestCase):
             sigmatuple[1],
             True)
         # population particle
-        weight = self.setup_weight(m, True)
+        weight = self.setup_weight(m, 2, True)
         # epsilon
         epsilon = self.setup_nuisance(
             m,

--- a/modules/isd/test/test_Weight.py
+++ b/modules/isd/test/test_Weight.py
@@ -43,13 +43,13 @@ class TestWeightParam(IMP.test.TestCase):
             list(wshift), list(wshift[0] * np.ones_like(wshift))
         )
 
-    def test_setup_dimension(self):
-        "Test setup weight with dimension"
+    def test_setup_number_of_weights(self):
+        "Test setup weight with number of weights"
         for n in range(1, 20):
             p = IMP.Particle(self.m)
             w = Weight.setup_particle(p, n)
             self.assertTrue(Weight.get_is_setup(p))
-            self.assertEqual(w.get_dimension(), n)
+            self.assertEqual(w.get_number_of_weights(), n)
             for k in range(n):
                 self.assertAlmostEqual(w.get_weight(k), 1.0 / n, delta=1e-6)
 
@@ -60,7 +60,7 @@ class TestWeightParam(IMP.test.TestCase):
             ws = np.random.uniform(size=n)
             w = Weight.setup_particle(p, ws)
             self.assertTrue(Weight.get_is_setup(p))
-            self.assertEqual(w.get_dimension(), n)
+            self.assertEqual(w.get_number_of_weights(), n)
             self._test_projected_weights(ws, w.get_weights())
 
     def test_set_weights(self):

--- a/modules/isd/test/test_Weight.py
+++ b/modules/isd/test/test_Weight.py
@@ -10,6 +10,8 @@ from IMP.isd import Weight
 # unit testing framework
 import IMP.test
 
+import numpy as np
+
 
 class TestWeightParam(IMP.test.TestCase):
 
@@ -20,66 +22,127 @@ class TestWeightParam(IMP.test.TestCase):
         # IMP.set_log_level(IMP.MEMORY)
         IMP.set_log_level(0)
         self.m = IMP.Model()
-        self.w = Weight.setup_particle(IMP.Particle(self.m))
 
-    def test_Setup_iw(self):
-        "Test weight_initial_values"
-        w = Weight.setup_particle(IMP.Particle(self.m))
-        w.add_weight()
-        for n in range(19):
-            for k in range(n + 1):
-                self.assertEqual(w.get_weight(k), 1.0 / (n + 1))
-            w.add_weight()
+    def _test_projected_weights(self, ws, ws_proj):
+        ws = np.array([ws[i] for i in range(len(ws))])
+        ws_proj = np.array([ws_proj[i] for i in range(len(ws_proj))])
+        pos_inds = ws_proj != 0.0
+        wshift = ws[pos_inds] - ws_proj[pos_inds]
 
-    def test_Setup_number(self):
-        "Test weights_initial_values"
-        w = Weight.setup_particle(IMP.Particle(self.m))
-        w.add_weight()
-        for n in range(19):
-            ws = w.get_weights()
-            self.assertEqual(len(ws), n + 1)
-            for k in range(n + 1):
-                self.assertEqual(ws[k], 1.0 / (n + 1))
-            w.add_weight()
+        self.assertTrue(np.all(ws_proj >= 0))
+        self.assertAlmostEqual(np.sum(ws_proj), 1)
 
-    def test_Setup_size(self):
-        "Test weights_size"
-        w = Weight.setup_particle(IMP.Particle(self.m))
-        w.add_weight()
-        for n in range(19):
-            ws = w.get_weights()
-            ns = w.get_number_of_states()
-            self.assertEqual(n + 1, ns)
-            self.assertEqual(len(ws), ns)
-            w.add_weight()
+        # projection has cut point
+        if len(ws[~pos_inds]) > 0:
+            min_pos = np.amin(ws[pos_inds])
+            max_zero = np.amax(ws[~pos_inds])
+            self.assertGreater(min_pos, max_zero)
 
-    def test_assign_values(self):
-        "Test weights_set"
-        w = Weight.setup_particle(IMP.Particle(self.m))
-        w.add_weight()
-        ws = [1.0]
-        for n in range(19):
+        # projection is rigid shift
+        self.assertSequenceAlmostEqual(
+            list(wshift), list(wshift[0] * np.ones_like(wshift))
+        )
+
+    def test_setup_dimension(self):
+        "Test setup weight with dimension"
+        for n in range(1, 20):
+            p = IMP.Particle(self.m)
+            w = Weight.setup_particle(p, n)
+            self.assertTrue(Weight.get_is_setup(p))
+            self.assertEqual(w.get_dimension(), n)
+            for k in range(n):
+                self.assertAlmostEqual(w.get_weight(k), 1.0 / n, delta=1e-6)
+
+    def test_setup_weights(self):
+        "Test setup weight with initial values"
+        for n in range(1, 20):
+            p = IMP.Particle(self.m)
+            ws = np.random.uniform(size=n)
+            w = Weight.setup_particle(p, ws)
+            self.assertTrue(Weight.get_is_setup(p))
+            self.assertEqual(w.get_dimension(), n)
+            self._test_projected_weights(ws, w.get_weights())
+
+    def test_set_weights(self):
+        for n in range(1, 20):
+            p = IMP.Particle(self.m)
+            w = Weight.setup_particle(p, n)
+            ws = np.random.uniform(size=n)
             w.set_weights(ws)
-            ws2 = w.get_weights()
-            for k in range(n + 1):
-                self.assertEqual(ws[k], ws2[k])
-            ws.append(1.0)
-            w.add_weight()
+            self._test_projected_weights(ws, w.get_weights())
+
+    def test_set_weights_lazy(self):
+        for n in range(1, 20):
+            p = IMP.Particle(self.m)
+            w = Weight.setup_particle(p, n)
+            ws = np.random.uniform(size=n)
+            w.set_weights_lazy(ws)
+            for k in range(n):
+                self.assertAlmostEqual(w.get_weight(k), ws[k], delta=1e-6)
+
+            self.m.update()
+            self._test_projected_weights(ws, w.get_weights())
+
+    def test_set_weight_lazy(self):
+        for n in range(1, 20):
+            p = IMP.Particle(self.m)
+            w = Weight.setup_particle(p, n)
+            ws = np.random.uniform(size=n)
+            for k in range(n):
+                w.set_weight_lazy(k, ws[k])
+                self.assertAlmostEqual(w.get_weight(k), ws[k], delta=1e-6)
+
+            self.m.update()
+            self._test_projected_weights(ws, w.get_weights())
+
+    def test_set_weights_zero(self):
+        p = IMP.Particle(self.m)
+        n = 5
+        w = Weight.setup_particle(p, n)
+        ws = np.zeros(n)
+        w.set_weights(ws)
+        for k in range(n):
+            self.assertAlmostEqual(w.get_weight(k), 1 / n, delta=1e-6)
+
+    def test_add_to_weight_derivative(self):
+        for n in range(1, 20):
+            w = Weight.setup_particle(IMP.Particle(self.m), n)
+            ws = np.random.uniform(size=n)
+            ws /= np.sum(ws)
+            w.set_weights(ws)
+
+            for k in range(0, n):
+                dwk = np.random.normal()
+                w.add_to_weight_derivative(k, dwk, IMP.DerivativeAccumulator())
+                self.assertAlmostEqual(
+                    w.get_weight_derivative(k), dwk, delta=1e-6
+                )
+
+    def test_add_to_weights_derivatives(self):
+        for n in range(1, 20):
+            w = Weight.setup_particle(IMP.Particle(self.m), n)
+            ws = np.random.uniform(size=n)
+            ws /= np.sum(ws)
+            w.set_weights(ws)
+
+            dw = np.random.normal(size=n)
+            w.add_to_weights_derivatives(dw, IMP.DerivativeAccumulator())
+            dw2 = w.get_weights_derivatives()
+            dw2 = [dw2[i] for i in range(n)]
+            self.assertSequenceAlmostEqual(list(dw), dw2, delta=1e-6)
 
     def test_set_optimized(self):
         "Test weights_optimized"
-        w = Weight.setup_particle(IMP.Particle(self.m))
-        w.add_weight()
-        for n in range(19):
+        for n in range(1, 20):
+            w = Weight.setup_particle(IMP.Particle(self.m), n)
             w.set_weights_are_optimized(True)
-            for k in range(n + 1):
+            for k in range(n):
                 b = w.get_is_optimized(w.get_weight_key(k))
                 self.assertEqual(b, True)
             w.set_weights_are_optimized(False)
-            for k in range(n + 1):
+            for k in range(n):
                 b = w.get_is_optimized(w.get_weight_key(k))
                 self.assertEqual(b, False)
-            w.add_weight()
 
 
 if __name__ == '__main__':

--- a/modules/isd/test/test_mc_WeightMover.py
+++ b/modules/isd/test/test_mc_WeightMover.py
@@ -20,11 +20,12 @@ class TestWeightMover(IMP.test.TestCase):
         IMP.test.TestCase.setUp(self)
         # IMP.set_log_level(IMP.MEMORY)
         IMP.set_log_level(0)
+        self.setup_system(2)
+
+    def setup_system(self, nweights):
         self.m = IMP.Model()
-        self.w = Weight.setup_particle(IMP.Particle(self.m))
+        self.w = Weight.setup_particle(IMP.Particle(self.m), nweights)
         self.w.set_weights_are_optimized(True)
-        self.w.add_weight()
-        self.w.add_weight()
         self.wm = WeightMover(self.w, 0.1)
         self.mc = IMP.core.MonteCarlo(self.m)
         self.mc.set_scoring_function([])
@@ -34,16 +35,13 @@ class TestWeightMover(IMP.test.TestCase):
 
     def test_run(self):
         "Test weight mover mc run"
-        self.setUp()
         for n in range(5):
+            self.setup_system(n + 2)
             for j in range(10):
                 self.mc.optimize(10)
                 ws = self.w.get_weights()
-                sum = 0
-                for k in range(self.w.get_number_of_states()):
-                    sum += self.w.get_weight(k)
-                self.assertAlmostEqual(sum, 1.0, delta=0.0000001)
-            self.w.add_weight()
+                wsum = sum([ws[i] for i in range(len(ws))])
+                self.assertAlmostEqual(wsum, 1.0, delta=0.0000001)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR implements the changes detailed in #1018.

It also makes some changes to how Weights are setup. In most cases, changing the number of weights during scoring function evaluation would break the restraints that use `Weight`. Moreover, the previous implementation added all weight keys up to the maximum number to the particle, even if the desired dimension was much lower. That makes increasing the maximum number of weights allowed (currently 20) unattractive, but 20 as a maximum is quite low. In the future, the user would create a `Weight` with a dimension or initial weight vector. If the user needs to increase the number of weights, they would create a new `Weight`. The old way still works but is deprecated.

For thoroughness, the documentation and method names no longer mention states, since weights are quite general and aren't tied to multi-state modeling.

PMI will need some updates based on these changes, but that will be handled separately.