### PR TITLE
- Added the Residue-Protein Proximity restraint. This restraint is de…

### DIFF
--- a/modules/isd/include/ResidueProteinProximityRestraint.h
+++ b/modules/isd/include/ResidueProteinProximityRestraint.h
@@ -1,0 +1,83 @@
+/**
+ *  \file IMP/isd/ResidueProteinProximityRestraint.h
+ *  \brief Restraint a selection of particles (eg. a residue or 
+ *  segment) to be within  a certain distance of a second 
+ *  selection of particles (eg. a protein). 
+ *  Use to model data from mutagenesis experiments that disrupt
+ *  protein-protein interactions.
+ *
+ *  Copyright 2007-2022 IMP Inventors. All rights reserved.
+ *
+ */
+
+#ifndef IMPISD_RESIDUE_BINDING_RESTRAINT_H
+#define IMPISD_RESIDUE_BINDING_RESTRAINT_H
+#include "isd_config.h"
+#include <IMP/container/ListSingletonContainer.h>
+#include <IMP/container_macros.h>
+#include <IMP/PairContainer.h>
+#include <IMP/Restraint.h>
+#include <boost/unordered_map.hpp>
+
+IMPISD_BEGIN_NAMESPACE
+
+//! Apply harmonic restraint between a residue or fragment and a
+//! protein.
+
+class IMPISDEXPORT ResidueProteinProximityRestraint : public Restraint {
+public:
+  //! Create the restraint.
+ ResidueProteinProximityRestraint(IMP::Model *m,
+                                  Float cutoff = 6.0,
+                                  Float sigma = 3.0,
+                                  Float xi = 0.5,
+                                  bool part_of_log_score=false,
+                                  std::string name = "ResidueProteinProximityRestraint_%1%"); 
+ 
+  // add a contribution: general case
+  void add_pairs_container(PairContainer *pc);
+
+  // add particles list (for COM calculations)
+  void add_contribution_particles(const ParticleIndexes ppis1,
+                                  const ParticleIndexes ppis2);
+ 
+  //! Evaluate the restraint just for a subset of contribution indexes
+  double evaluate_for_contributions(Ints c) const;
+
+  //! Get number of contributions added to the restraint
+  unsigned get_number_of_contributions() const { return ppis_.size(); }
+
+  void set_sigma(Float sigma) { sigma_=sigma; }
+  
+  void set_cutoff(Float cutoff) { cutoff_=cutoff; }
+
+  void set_max_score(Float max_score) { max_score_=max_score; }
+  void set_yi(Float yi) { yi_=yi; }
+  void set_interpolation_factor(Float interpolation_factor) { interpolation_factor_=interpolation_factor; }
+ 
+  void set_part_of_log_score(bool hey) { part_of_log_score_=hey; }
+
+  virtual double unprotected_evaluate(IMP::DerivativeAccumulator *accum) const IMP_OVERRIDE;
+  virtual IMP::ModelObjectsTemp do_get_inputs() const IMP_OVERRIDE;
+  
+  IMP_OBJECT_METHODS(ResidueProteinProximityRestraint);
+ private:
+  Float cutoff_;
+  Float sigma_;
+  Float xi_;
+  Float yi_;
+  Float interpolation_factor_;
+  Float max_score_;
+  bool part_of_log_score_;
+  PairContainers contribs_;
+  ParticleIndexes ppis_;
+  Ints default_range_;
+  std::vector<IMP::core::XYZRs> coms1_;
+  std::vector<IMP::core::XYZRs> coms2_;
+  
+};
+
+IMPISD_END_NAMESPACE
+
+#endif /* IMPISD_RESIDUE_PROTEIN_PROXIMITY_RESTRAINT_H */
+

--- a/modules/isd/include/ResidueProteinProximityRestraint.h
+++ b/modules/isd/include/ResidueProteinProximityRestraint.h
@@ -1,6 +1,6 @@
 /**
  *  \file IMP/isd/ResidueProteinProximityRestraint.h
- *  \brief Restraint a selection of particles (eg. a residue or 
+ *  \brief Restrain a selection of particles (eg. a residue or 
  *  segment) to be within  a certain distance of a second 
  *  selection of particles (eg. a protein). 
  *  Use to model data from mutagenesis experiments that disrupt
@@ -10,8 +10,8 @@
  *
  */
 
-#ifndef IMPISD_RESIDUE_BINDING_RESTRAINT_H
-#define IMPISD_RESIDUE_BINDING_RESTRAINT_H
+#ifndef IMPISD_RESIDUE_PROTEIN_PROXIMITY_RESTRAINT_H
+#define IMPISD_RESIDUE_PROTEIN_PROXIMITY_RESTRAINT_H
 #include "isd_config.h"
 #include <IMP/container/ListSingletonContainer.h>
 #include <IMP/container_macros.h>
@@ -27,10 +27,10 @@ IMPISD_BEGIN_NAMESPACE
 class IMPISDEXPORT ResidueProteinProximityRestraint : public Restraint {
 public:
   //! Create the restraint.
- ResidueProteinProximityRestraint(IMP::Model *m,
-                                  Float cutoff = 6.0,
-                                  Float sigma = 3.0,
-                                  Float xi = 0.5,
+ ResidueProteinProximityRestraint(Model *m,
+                                  double cutoff = 6.0,
+                                  double sigma = 3.0,
+                                  double xi = 0.5,
                                   bool part_of_log_score=false,
                                   std::string name = "ResidueProteinProximityRestraint_%1%"); 
  
@@ -47,27 +47,30 @@ public:
   //! Get number of contributions added to the restraint
   unsigned get_number_of_contributions() const { return ppis_.size(); }
 
-  void set_sigma(Float sigma) { sigma_=sigma; }
+  void set_sigma(double sigma) { sigma_=sigma; }
   
-  void set_cutoff(Float cutoff) { cutoff_=cutoff; }
+  void set_cutoff(double cutoff) { cutoff_=cutoff; }
 
-  void set_max_score(Float max_score) { max_score_=max_score; }
-  void set_yi(Float yi) { yi_=yi; }
-  void set_interpolation_factor(Float interpolation_factor) { interpolation_factor_=interpolation_factor; }
+  void set_max_score(double max_score) { max_score_=max_score; }
+  
+  void set_yi(double yi) { yi_=yi; }
+  
+  void set_interpolation_factor(double interpolation_factor) { interpolation_factor_=interpolation_factor; }
  
   void set_part_of_log_score(bool hey) { part_of_log_score_=hey; }
 
-  virtual double unprotected_evaluate(IMP::DerivativeAccumulator *accum) const IMP_OVERRIDE;
+  virtual double unprotected_evaluate(DerivativeAccumulator *accum) const IMP_OVERRIDE;
+  
   virtual IMP::ModelObjectsTemp do_get_inputs() const IMP_OVERRIDE;
   
   IMP_OBJECT_METHODS(ResidueProteinProximityRestraint);
  private:
-  Float cutoff_;
-  Float sigma_;
-  Float xi_;
-  Float yi_;
-  Float interpolation_factor_;
-  Float max_score_;
+  double cutoff_;
+  double sigma_;
+  double xi_;
+  double yi_;
+  double interpolation_factor_;
+  double max_score_;
   bool part_of_log_score_;
   PairContainers contribs_;
   ParticleIndexes ppis_;
@@ -80,4 +83,3 @@ public:
 IMPISD_END_NAMESPACE
 
 #endif /* IMPISD_RESIDUE_PROTEIN_PROXIMITY_RESTRAINT_H */
-

--- a/modules/isd/pyext/swig.i-in
+++ b/modules/isd/pyext/swig.i-in
@@ -58,6 +58,7 @@ IMP_SWIG_OBJECT(IMP::isd, AtomicCrossLinkMSRestraint, AtomicCrossLinkMSRestraint
 IMP_SWIG_OBJECT(IMP::isd, GaussianEMRestraint, GaussianEMRestraints);
 IMP_SWIG_OBJECT(IMP::isd, GaussianAnchorEMRestraint, GaussianAnchorEMRestraints);
 IMP_SWIG_OBJECT(IMP::isd, GammaPrior, GammaPriors);
+IMP_SWIG_OBJECT(IMP::isd, ResidueProteinProximityRestraint, ResidueProteinProximityRestraints);
 
 /* One can add python methods to your module by putting code in %pythoncode blocks
    This function can be called as IMP.isds.say_hello(). */
@@ -125,3 +126,4 @@ def create_model_and_particles():
 %include "IMP/isd/GaussianAnchorEMRestraint.h"
 %include "IMP/isd/GammaPrior.h"
 %include "IMP/isd/em_utilities.h"
+%include "IMP/isd/ResidueProteinProximityRestraint.h"

--- a/modules/isd/src/ResidueProteinProximityRestraint.cpp
+++ b/modules/isd/src/ResidueProteinProximityRestraint.cpp
@@ -1,0 +1,159 @@
+/**
+ *  \file isd/ResidueProteinProximityRestraint.h
+ *  \brief Restraint a selection of particles (eg. a residue or 
+ *  segment) to be within  a certain distance of a second 
+ *  selection of particles (eg. a protein). 
+ *  Use to model data from mutagenesis experiments that disrupt
+ *  protein-protein interactions.
+ *
+ *  Copyright 2007-2022 IMP Inventors. All rights reserved.
+ *
+ */
+
+#include <IMP/isd/ResidueProteinProximityRestraint.h>
+#include <IMP/algebra/VectorD.h>
+#include <IMP/core/XYZ.h>
+#include <IMP/isd/Scale.h>
+#include <IMP/container/ListPairContainer.h>
+#include <boost/math/special_functions/erf.hpp>
+#include <boost/unordered_map.hpp>
+#include <boost/tuple/tuple.hpp>
+#include <math.h>
+
+IMPISD_BEGIN_NAMESPACE
+
+ResidueProteinProximityRestraint::ResidueProteinProximityRestraint(Model* m,
+						 Float cutoff,
+						 Float sigma,
+                                                 Float xi,
+						 bool part_of_log_score,
+						 std::string name):
+  Restraint(m,name),
+  cutoff_(cutoff),
+  sigma_(sigma),
+  xi_(xi),
+  part_of_log_score_(part_of_log_score)
+  {
+}
+
+// add a contribution: general case
+void ResidueProteinProximityRestraint::add_pairs_container(PairContainer *pc) {
+  contribs_.push_back(pc);
+  default_range_.push_back((int)default_range_.size());
+}
+
+void ResidueProteinProximityRestraint::add_contribution_particles(const ParticleIndexes ppis1,
+                                                         const ParticleIndexes ppis2){
+
+  ParticlesTemp pps1;
+  ParticlesTemp pps2;
+  for (unsigned int i = 0; i < ppis1.size(); i++){
+    pps1.push_back(get_model()->get_particle(ppis1[i]));
+    ppis_.push_back(ppis1[i]);
+  }
+  for (unsigned int i = 0; i < ppis2.size(); i++){
+    pps2.push_back(get_model()->get_particle(ppis2[i]));
+    ppis_.push_back(ppis2[i]);
+  }
+  
+  IMP::core::XYZRs xx1 = IMP::core::XYZRs(pps1);
+  IMP::core::XYZRs xx2 = IMP::core::XYZRs(pps2);
+
+  algebra::Vector3D centroid1 = core::get_centroid(xx1);
+  algebra::Vector3D centroid2 = core::get_centroid(xx2);
+  
+  coms1_.push_back(xx1);
+  coms2_.push_back(xx2);
+  //sigmass_.push_back(sigmas);
+}
+
+double ResidueProteinProximityRestraint::evaluate_for_contributions(Ints c)
+  const{
+
+  double score_tot = 0.0;
+  double score = 0.0;
+  //! Loop over the contributions and score things
+  for (Ints::const_iterator nit=c.begin();nit!=c.end();++nit){
+    int n = *nit;
+
+    //! Get COM
+    algebra::Vector3D centroid1 = core::get_centroid(coms1_[n]);
+    algebra::Vector3D centroid2 = core::get_centroid(coms2_[n]);
+    Float dist = IMP::algebra::get_distance(centroid1, centroid2);
+    
+   
+    //! Compute distances. Loop elements of close pair
+    Vector<double> dists_;
+    IMP_CONTAINER_FOREACH(PairContainer, contribs_[n], {
+	//! Distances 
+	core::XYZ d0(get_model(), _1[0]);
+	core::XYZ d1(get_model(), _1[1]);
+	double dist = get_distance(d0,d1);
+	dists_.push_back(dist);
+	
+	//! Get particles indexes
+	ParticleIndex pi1 = get_model()->get_particle(_1[0])->get_index();
+	ParticleIndex pi2 = get_model()->get_particle(_1[1])->get_index();
+	
+      });
+
+    if(!dists_.empty()) {
+      double lowest_dist = *min_element(dists_.begin(), dists_.end());
+      if (lowest_dist <= cutoff_/2.) {
+        Float prior_prob = std::exp(-xi_*lowest_dist);
+        Float prior_score = -log(prior_prob);
+	score = prior_score;  
+      }
+      else if (lowest_dist > cutoff_/2. && lowest_dist <= cutoff_) {
+        double interpolation_prob = std::exp(-yi_*lowest_dist);
+        score = -log(interpolation_prob) - interpolation_factor_;
+      }
+      else {
+        Float prior_prob = std::exp(-xi_*lowest_dist);
+	double sig2 = sigma_*sigma_;
+        double ld2 = lowest_dist*lowest_dist;
+        double prob = std::exp(-ld2/(2*sig2))/(sq2Pi*sigma_);
+        score = -log(prior_prob*prob);
+        
+      }
+      score_tot +=  score;
+    }
+    else {
+      Float prior_prob = std::exp(-xi_*dist);
+      Float prior_score = -log(prior_prob);
+      score_tot +=  max_score_ + prior_score;
+    }
+  }
+  return score_tot;
+}
+
+double ResidueProteinProximityRestraint::unprotected_evaluate(DerivativeAccumulator *accum)
+  const {
+
+  Float output_score = evaluate_for_contributions(default_range_);
+  return output_score;
+}
+
+ModelObjectsTemp ResidueProteinProximityRestraint::do_get_inputs() const {
+    ParticlesTemp ret;
+    for (unsigned int k = 0; k < get_number_of_contributions(); ++k) {
+      ret.push_back(get_model()->get_particle(ppis_[k]));
+    }
+    return ret;
+}
+
+IMPISD_END_NAMESPACE
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/modules/isd/src/ResidueProteinProximityRestraint.cpp
+++ b/modules/isd/src/ResidueProteinProximityRestraint.cpp
@@ -1,6 +1,6 @@
 /**
  *  \file isd/ResidueProteinProximityRestraint.h
- *  \brief Restraint a selection of particles (eg. a residue or 
+ *  \brief Restrain a selection of particles (eg. a residue or 
  *  segment) to be within  a certain distance of a second 
  *  selection of particles (eg. a protein). 
  *  Use to model data from mutagenesis experiments that disrupt
@@ -23,11 +23,11 @@
 IMPISD_BEGIN_NAMESPACE
 
 ResidueProteinProximityRestraint::ResidueProteinProximityRestraint(Model* m,
-						 Float cutoff,
-						 Float sigma,
-                                                 Float xi,
-						 bool part_of_log_score,
-						 std::string name):
+                                                                   double cutoff,
+                                                                   double sigma,
+                                                                   double xi,
+                                                                   bool part_of_log_score,
+                                                                   std::string name):
   Restraint(m,name),
   cutoff_(cutoff),
   sigma_(sigma),
@@ -39,11 +39,11 @@ ResidueProteinProximityRestraint::ResidueProteinProximityRestraint(Model* m,
 // add a contribution: general case
 void ResidueProteinProximityRestraint::add_pairs_container(PairContainer *pc) {
   contribs_.push_back(pc);
-  default_range_.push_back((int)default_range_.size());
+  default_range_.push_back(static_cast<int>(default_range_.size()));
 }
 
 void ResidueProteinProximityRestraint::add_contribution_particles(const ParticleIndexes ppis1,
-                                                         const ParticleIndexes ppis2){
+                                                                  const ParticleIndexes ppis2){
 
   ParticlesTemp pps1;
   ParticlesTemp pps2;
@@ -73,14 +73,12 @@ double ResidueProteinProximityRestraint::evaluate_for_contributions(Ints c)
   double score_tot = 0.0;
   double score = 0.0;
   //! Loop over the contributions and score things
-  for (Ints::const_iterator nit=c.begin();nit!=c.end();++nit){
-    int n = *nit;
+  for (int n : c){
 
     //! Get COM
     algebra::Vector3D centroid1 = core::get_centroid(coms1_[n]);
     algebra::Vector3D centroid2 = core::get_centroid(coms2_[n]);
-    Float dist = IMP::algebra::get_distance(centroid1, centroid2);
-    
+    double dist = IMP::algebra::get_distance(centroid1, centroid2);
    
     //! Compute distances. Loop elements of close pair
     Vector<double> dists_;
@@ -94,14 +92,13 @@ double ResidueProteinProximityRestraint::evaluate_for_contributions(Ints c)
 	//! Get particles indexes
 	ParticleIndex pi1 = get_model()->get_particle(_1[0])->get_index();
 	ParticleIndex pi2 = get_model()->get_particle(_1[1])->get_index();
-	
       });
 
     if(!dists_.empty()) {
       double lowest_dist = *min_element(dists_.begin(), dists_.end());
       if (lowest_dist <= cutoff_/2.) {
-        Float prior_prob = std::exp(-xi_*lowest_dist);
-        Float prior_score = -log(prior_prob);
+        double prior_prob = std::exp(-xi_*lowest_dist);
+        double prior_score = -log(prior_prob);
 	score = prior_score;  
       }
       else if (lowest_dist > cutoff_/2. && lowest_dist <= cutoff_) {
@@ -109,7 +106,7 @@ double ResidueProteinProximityRestraint::evaluate_for_contributions(Ints c)
         score = -log(interpolation_prob) - interpolation_factor_;
       }
       else {
-        Float prior_prob = std::exp(-xi_*lowest_dist);
+        double prior_prob = std::exp(-xi_*lowest_dist);
 	double sig2 = sigma_*sigma_;
         double ld2 = lowest_dist*lowest_dist;
         double prob = std::exp(-ld2/(2*sig2))/(sq2Pi*sigma_);
@@ -119,8 +116,8 @@ double ResidueProteinProximityRestraint::evaluate_for_contributions(Ints c)
       score_tot +=  score;
     }
     else {
-      Float prior_prob = std::exp(-xi_*dist);
-      Float prior_score = -log(prior_prob);
+      double prior_prob = std::exp(-xi_*dist);
+      double prior_score = -log(prior_prob);
       score_tot +=  max_score_ + prior_score;
     }
   }
@@ -130,7 +127,7 @@ double ResidueProteinProximityRestraint::evaluate_for_contributions(Ints c)
 double ResidueProteinProximityRestraint::unprotected_evaluate(DerivativeAccumulator *accum)
   const {
 
-  Float output_score = evaluate_for_contributions(default_range_);
+  double output_score = evaluate_for_contributions(default_range_);
   return output_score;
 }
 
@@ -143,16 +140,6 @@ ModelObjectsTemp ResidueProteinProximityRestraint::do_get_inputs() const {
 }
 
 IMPISD_END_NAMESPACE
-
-
-
-
-
-
-
-
-
-
 
 
 

--- a/modules/pmi/examples/protein_residue_binding.py
+++ b/modules/pmi/examples/protein_residue_binding.py
@@ -1,0 +1,119 @@
+## \example pmi/protein_residue_binding.py
+"""
+This script shows how to simulate residue–protein 
+binding contacts inferred from mutagenesis studies.
+This example shows protein A binding to protein B 
+through a set of residues predicted to be required 
+for binding in mutagensis studies.
+"""
+
+from __future__ import print_function
+import IMP
+import IMP.atom
+import IMP.rmf
+import IMP.pmi
+import IMP.pmi.topology
+import IMP.pmi.dof
+import IMP.pmi.macros
+import IMP.pmi.restraints
+import IMP.pmi.restraints.stereochemistry
+import IMP.pmi.restraints.basic
+import IMP.pmi.restraints.residue_proximity_restraint
+import tempfile
+import os
+import sys
+
+topology = '''
+|molecule_name|color|fasta_fn|fasta_id|pdb_fn|chain|residue_range|pdb_offset|bead_size|em_residues_per_gaussian|rigid_body|super_rigid_body|chain_of_super_rigid_bodies|
+|Rpb4  |red   |1WCM.fasta |1WCM:D   |1WCM_fitted.pdb    |D|1,END  |0 |5|0 |1 | | ||
+|Rpb7  |gold  |1WCM.fasta |1WCM:G   |1WCM_fitted.pdb    |G|1,END  |0 |5|0 |2 | | ||
+'''
+
+# Normally the topology table is kept in a text file but here we just write
+# it to a temporary one
+tf = tempfile.NamedTemporaryFile(delete=False, mode='w')
+tf.write(topology)
+tf.close()
+
+print(IMP.pmi.get_example_path('data/'))
+
+# The TopologyReader reads the text file, and the BuildSystem macro
+# constructs it
+mdl = IMP.Model()
+reader = IMP.pmi.topology.TopologyReader(
+    tf.name, pdb_dir=IMP.pmi.get_example_path('data/'),
+    fasta_dir=IMP.pmi.get_example_path('data/'),
+    gmm_dir=IMP.pmi.get_example_path('data/'))
+bs = IMP.pmi.macros.BuildSystem(mdl)
+# note you can call this multiple times to create a multi-state system
+bs.add_state(reader)
+hier, dof = bs.execute_macro()
+
+# ################ STEREOCHEMISTRY RESTRAINTS ################
+
+output_objects = []  # keep a list of functions that need to be reported
+
+# Connectivity keeps things connected along the backbone (ignores if inside
+# same rigid body)
+crs = []
+moldict = bs.get_molecules()[0]
+mols = []
+for molname in moldict:
+    for mol in moldict[molname]:
+        cr = IMP.pmi.restraints.stereochemistry.ConnectivityRestraint(mol)
+        cr.add_to_model()
+        output_objects.append(cr)
+        crs.append(cr)
+        mols.append(mol)
+
+# Excluded volume - automatically more efficient due to rigid bodies
+evr = IMP.pmi.restraints.stereochemistry.ExcludedVolumeSphere(
+    included_objects=mols)
+evr.add_to_model()
+output_objects.append(evr)
+
+# External barrier- Avoid proteins to drift away
+eb = IMP.pmi.restraints.basic.ExternalBarrier(hierarchies=hier, radius=500)
+eb.add_to_model()
+
+# ################# PROTEIN-RESIDUE PROXIMITY ################
+
+br = IMP.pmi.restraints.residue_proximity_restraint.ResidueProteinProximityRestraint(
+    hier,
+    selection  = ('Rpb7',38, 44, 'Rpb4'),
+    label = 'B38_44') 
+
+br.add_to_model()
+br.set_weight(5.0)
+output_objects.append(br)
+br.get_output()
+
+# ##################### SAMPLING #######################
+
+# Fix rigid-body 
+
+part_p1=IMP.atom.Selection(hier,
+                           molecule="Rpb4").get_selected_particles()
+
+xyzs, rbs=dof.disable_movers(part_p1,
+                                mover_types=[IMP.core.RigidBodyMover])
+
+
+# mix it up so it looks cool
+IMP.pmi.tools.shuffle_configuration(hier)
+
+# Quickly move all flexible beads into place
+dof.optimize_flexible_beads(100)
+
+rex = IMP.pmi.macros.ReplicaExchange0(
+    mdl,
+    root_hier=hier,
+    monte_carlo_sample_objects=dof.get_movers(),
+    global_output_directory='output/',
+    output_objects=output_objects,
+    monte_carlo_steps=10,
+    number_of_best_scoring_models=0,
+    number_of_frames=5000)
+rex.execute_macro()
+
+os.remove(tf.name)

--- a/modules/pmi/pyext/src/restraints/residue_proximity_restraint.py
+++ b/modules/pmi/pyext/src/restraints/residue_proximity_restraint.py
@@ -1,0 +1,158 @@
+from __future__ import print_function
+import IMP
+import IMP.core
+import IMP.algebra
+import IMP.atom
+import IMP.container
+import IMP.pmi.tools
+import IMP.pmi.restraints
+
+import math
+import numpy as np
+
+class ResidueProteinProximityRestraint(IMP.pmi.restraints.RestraintBase):
+
+    """ Restraint residue/residues to bind to unknown location in a target"""
+
+    def __init__(self,
+                 hier,
+                 selection,
+                 cutoff = 6.,
+                 sigma = 3.,
+                 xi = 0.01,
+                 resolution=1.0,
+                 weight = 1.0,
+                 label = None):
+        """
+        Constructor
+        @ param hier        Hierarchy of the system
+        @ param section     Selection of residues and target
+                            syntaxis (prot, r1, r2, target_prot)  or  
+                            (prot1, r1, r2, target_prot, target_r1, target_r2) 
+        @ param cutoff      Distance cutoff between selected segment and target
+                            protein 
+        @ param sigma       Distance variance between selected fragments
+        @ param xi          Slope of a distance-linear scoring function that funnels 
+                            the score when the particles are too far away
+        @ param resolution  Resolution at which apply restraint
+        @ param weight      Weight of the restraint
+        @ param label       Extra text to label the restraint so that it is
+                            searchable in the output 
+        """
+        self.hier = hier
+        m = self.hier.get_model()
+
+        rname = "ResidueProteinProximityRestraint"
+        super(ResidueProteinProximityRestraint, self).__init__(
+            m, name="ResidueProteinProximityRestraint", label=label, weight=weight)
+
+        self.cutoff = cutoff
+        self.sigma = sigma
+        self.xi = xi
+        self.resolution = resolution
+
+        # Check selection
+        print('selection', selection, isinstance(selection, tuple))
+        if (not isinstance(selection, tuple)) and (not isinstance(selection, list)):
+            raise ValueError("Selection should be a tuple or list")
+        if len(selection) < 4:
+            raise ValueError("Selection should be (prot, r1, r2, target_prot) or \
+                             (prot1, r1, r2, target_prot, target_r1, target_r2) ")
+
+        # Selection
+        self.prot1 = selection[0]
+        self.r1 = int(selection[1])
+        self.r2 = int(selection[2])
+
+        self.prot2 = selection[3]
+        if len(selection) == 6:
+            self.tr1 = int(selection[4])
+            self.tr2 = int(selection[5])        
+ 
+        if self.r1 == self.r2:
+            sel_resi = IMP.atom.Selection(self.hier,
+                                          molecule = self.prot1,
+                                          residue_index = self.r1,
+                                          resolution = self.resolution).get_selected_particles()
+        else:
+            sel_resi = IMP.atom.Selection(self.hier,
+                                          molecule = self.prot1,
+                                          residue_indexes = range(self.r1,self.r2+1,1),
+                                          resolution = self.resolution).get_selected_particles()
+
+        if len(selection) == 4:
+            sel_target = IMP.atom.Selection(self.hier,
+                                            molecule=self.prot2,
+                                            resolution=self.resolution).get_selected_particles()
+
+        elif len(selection) == 6:
+            sel_target = IMP.atom.Selection(self.hier,
+                                            molecule=self.prot2,
+                                            residue_indexes = range(self.tr1,self.tr2+1,1),
+                                            resolution=self.resolution).get_selected_particles()
+
+            
+        self.included_ps = sel_resi + sel_target
+        
+        # Setup restraint
+        distance = 0.0
+        slack = cutoff*2      
+  
+        br = IMP.isd.ResidueProteinProximityRestraint(m,
+                                                      self.cutoff,
+                                                      self.sigma,
+                                                      self.xi, 
+                                                      True,
+                                                      'ResidueProteinProximityRestraint')
+
+        print('Selected fragment and target lengths:', len(sel_resi), len(sel_target))
+        
+        # Setup close pair container
+        # Find close pair within included_resi and included_target
+        lsa_target = IMP.container.ListSingletonContainer(m)
+        lsa_target.add(IMP.get_indexes(sel_target))
+        
+        lsa_resi = IMP.container.ListSingletonContainer(m)
+        lsa_resi.add(IMP.get_indexes(sel_resi))
+        
+        self.cpc = IMP.container.CloseBipartitePairContainer(lsa_resi,
+                                                             lsa_target,
+                                                             distance,
+                                                             slack)
+                
+        br.add_pairs_container(self.cpc)
+
+        # Add particle indexes
+        pis1 = [p.get_index() for p in sel_resi]
+        pis2 = [p.get_index() for p in sel_target]
+        
+        br.add_contribution_particles(sel_resi, sel_target)
+
+        # Compute interpolation paramaters
+        yi = (cutoff**2/(2*sigma**2)-math.log(1/math.sqrt(2*math.pi*sigma*sigma))+cutoff*xi/2.)/(cutoff/2.)
+        interpolation_factor = -(cutoff/2.)*(xi-yi)
+        max_p = math.exp(-((distance+slack)**2)/(2*sigma**2))/math.sqrt(2*math.pi*sigma*sigma)
+        max_score = -math.log(max_p)
+        
+        # Add interpolation parameters
+        br.set_yi(yi)
+        br.set_interpolation_factor(interpolation_factor)
+        br.set_max_score(max_score)
+        
+        self.rs.add_restraint(br)
+
+        self.restraint_sets = [self.rs] + self.restraint_sets[1:]
+
+    def get_container_pairs(self):
+        """ Get particles in the close pair container """
+        m = self.hier.get_model()
+        return self.cpc.get_indexes()
+
+    def get_output(self):
+        output = {}
+        score = self.weight * self.rs.unprotected_evaluate(None)
+        output["ResidueProteinProximityRestraint_score_" + self.label] = str(score)
+        
+        return output
+
+        

--- a/modules/pmi/test/test_residue_protein_proximity.py
+++ b/modules/pmi/test/test_residue_protein_proximity.py
@@ -1,0 +1,157 @@
+from __future__ import print_function, division
+import IMP
+import IMP.test
+import IMP.core
+import IMP.pmi
+import IMP.pmi.restraints
+import IMP.pmi.restraints.residue_proximity_restraint
+import math
+
+class Tests(IMP.test.TestCase):
+
+    def setup_system(self, ):
+
+        mdl = IMP.Model()
+        s = IMP.pmi.topology.System(mdl)
+        st1 = s.create_state()
+        
+        pA = st1.create_molecule('ProtA', 'A', chain_id='A')
+        pA.add_representation(pA, resolutions=[1], color='red')
+
+        pB = st1.create_molecule('ProtB', 'A', chain_id='A')
+        pB.add_representation(pB, resolutions=[1], color='blue')
+        
+        root_hier = s.build()
+        
+        return root_hier, pA, pB
+
+    def get_score(self, distance, sigma, xi):
+        prior_prob = math.exp(-xi*distance)
+        prob = math.exp(-(distance**2)/(2*sigma**2))/math.sqrt(2*math.pi*sigma*sigma)
+        score = -math.log(prob*prior_prob)
+        return score
+        
+
+    def test_ResidueProteinProximityRestraint_min_score(self):
+        root_hier, pA, pB = self.setup_system()
+        mdl = root_hier.get_model()
+        
+        # Translate one bead
+        trans = IMP.algebra.Transformation3D([2, 0, 0])
+        for fb in IMP.core.get_leaves(pB.get_hierarchy()):
+            IMP.core.transform(IMP.core.XYZ(fb), trans)
+
+        xi = 0.01
+        br_rest = IMP.pmi.restraints.residue_proximity_restraint.ResidueProteinProximityRestraint(root_hier,
+                                                                                                  selection  = ('ProtA',1,1,'ProtB'))
+        br_rest.add_to_model()
+        mdl.update()
+
+        min_score = -math.log(math.exp(-xi*2.))
+        self.assertAlmostEqual(br_rest.evaluate(), min_score, delta = 0.01)
+
+        
+
+    def test_ResidueProteinProximityRestraint_continuity1(self):
+        root_hier, pA, pB = self.setup_system()
+        mdl = root_hier.get_model()
+
+        cutoff = 6.
+        xi = 0.01
+        
+        # Translate one bead
+        trans = IMP.algebra.Transformation3D([cutoff/2., 0, 0])
+        for fb in IMP.core.get_leaves(pB.get_hierarchy()):
+            IMP.core.transform(IMP.core.XYZ(fb), trans)
+
+        br_rest = IMP.pmi.restraints.residue_proximity_restraint.ResidueProteinProximityRestraint(root_hier,
+                                                                                                  selection  = ('ProtA',1,2,'ProtB'))
+        br_rest.add_to_model()
+        mdl.update()
+
+        score_1 = br_rest.evaluate()
+        
+        trans = IMP.algebra.Transformation3D([0.01, 0, 0])
+        for fb in IMP.core.get_leaves(pB.get_hierarchy()):
+            IMP.core.transform(IMP.core.XYZ(fb), trans)
+
+        score_2 = br_rest.evaluate()
+
+        print(score_1, score_2)
+        self.assertGreater(score_2, score_1)
+        self.assertAlmostEqual(score_1, score_2, delta = 0.02)
+
+    def test_ResidueProteinProximityRestraint_continuity2(self):
+        root_hier, pA, pB = self.setup_system()
+        mdl = root_hier.get_model()
+
+        cutoff = 6.
+        xi = 0.01
+        
+        # Translate one bead
+        trans = IMP.algebra.Transformation3D([cutoff, 0, 0])
+        for fb in IMP.core.get_leaves(pB.get_hierarchy()):
+            IMP.core.transform(IMP.core.XYZ(fb), trans)
+
+        br_rest = IMP.pmi.restraints.residue_proximity_restraint.ResidueProteinProximityRestraint(root_hier,
+                                                                                                  selection  = ('ProtA',1,2,'ProtB'))
+        br_rest.add_to_model()
+        mdl.update()
+
+        score_1 = br_rest.evaluate()
+        
+        trans = IMP.algebra.Transformation3D([0.01, 0, 0])
+        for fb in IMP.core.get_leaves(pB.get_hierarchy()):
+            IMP.core.transform(IMP.core.XYZ(fb), trans)
+
+        score_2 = br_rest.evaluate()
+
+        self.assertGreater(score_2, score_1)
+        self.assertAlmostEqual(score_1, score_2, delta = 0.02)
+
+    def test_ResidueProteinProximityRestraint_score(self):
+        root_hier, pA, pB = self.setup_system()
+        mdl = root_hier.get_model()
+
+        distance = 8.
+        xi = 0.01
+        sigma = 3.0
+
+        # Translate one bead
+        trans = IMP.algebra.Transformation3D([distance, 0, 0])
+        for fb in IMP.core.get_leaves(pB.get_hierarchy()):
+            IMP.core.transform(IMP.core.XYZ(fb), trans)
+
+        br_rest = IMP.pmi.restraints.residue_proximity_restraint.ResidueProteinProximityRestraint(root_hier,
+                                                                                                  selection  = ('ProtA',1,2,'ProtB'))
+        br_rest.add_to_model()
+        mdl.update()
+
+        score = self.get_score(distance, sigma, xi)
+        
+        self.assertAlmostEqual(br_rest.evaluate(), score, delta = 0.02)
+
+    def test_ResidueProteinProximityRestraint_pairs(self):
+        root_hier, pA, pB = self.setup_system()
+        mdl = root_hier.get_model()
+
+        distance = 8.
+        xi = 0.01
+        sigma = 3.0
+
+        # Translate one bead
+        trans = IMP.algebra.Transformation3D([3., 0, 0])
+        for fb in IMP.core.get_leaves(pB.get_hierarchy()):
+            IMP.core.transform(IMP.core.XYZ(fb), trans)
+
+        br_rest = IMP.pmi.restraints.residue_proximity_restraint.ResidueProteinProximityRestraint(root_hier,
+                                                                                                  selection  = ('ProtA',1,2,'ProtB'))
+        br_rest.add_to_model()
+        mdl.update()
+        
+        self.assertEqual(len(br_rest.get_container_pairs()), 1)
+        self.assertEqual(len(br_rest.get_container_pairs()[0]), 2)
+
+
+if __name__ == '__main__':
+    IMP.test.main()


### PR DESCRIPTION
…signed to restraint the distance between a residue or fragment and a proteins. Can be used,
for example, to model mutagenesis data that indicates which protein regions are
implicated in protein-protein interactions.

- The PMI wrapper `residue_proximity_restraint.py` allows to add the restraint
to standard protein selections.

- The example `residue_proximity_restraint.py` shows a two protein system.