### PR TITLE
Changing "purity" to "precision"

### DIFF
--- a/modules/spatiotemporal/README.md
+++ b/modules/spatiotemporal/README.md
@@ -87,8 +87,8 @@ labaled_pdf2_fn - labeled_pdf from another independent sampling
 
 output_fn - name of output file (default: 'temporal_precision.txt')
 
-### purity(labeled_pdf_fn,output_fn)
-Function that reads in one labeled_pdf from create_DAG and returns the purity, defined as the sum of the squared probability of all trajectories.
+### precision(labeled_pdf_fn,output_fn)
+Function that reads in one labeled_pdf from create_DAG and returns the precision, defined as the sum of the squared probability of all trajectories.
 
 labeled_pdf_fn - labeled_pdf from the total model
 

--- a/modules/spatiotemporal/pyext/src/analysis.py
+++ b/modules/spatiotemporal/pyext/src/analysis.py
@@ -78,16 +78,16 @@ def temporal_precision(labeled_pdf1_fn, labeled_pdf2_fn,
     print(precision)
 
 
-def purity(labeled_pdf_fn, output_fn='purity.txt'):
+def precision(labeled_pdf_fn, output_fn='precision.txt'):
     """
     Function that reads in one labeled_pdf from create_DAG and returns the
-    purity, defined as the sum of the squared probability of all trajectories.
+    precision, defined as the sum of the squared probability of all trajectories.
 
     @param labeled_pdf_fn: string, labeled pdf file name (including the path);
            labeled_pdf from the total model
     @param output_fn: string, name of output file
            (default: 'temporal_precision.txt')
-    @return temporal purity, written to output_fn
+    @return temporal precision, written to output_fn
     """
     # create blank dictonary to store the results
     prob_list = []
@@ -114,7 +114,7 @@ def purity(labeled_pdf_fn, output_fn='purity.txt'):
     for prob in prob_list:
         pure += prob * prob
     with open(output_fn, 'w') as new:
-        new.write('Purity of ' + labeled_pdf_fn + ':\n')
+        new.write('Precision of ' + labeled_pdf_fn + ':\n')
         new.write(str(pure))
-    print('Purity of ' + labeled_pdf_fn)
+    print('Precision of ' + labeled_pdf_fn)
     print(str(pure))

--- a/modules/spatiotemporal/pyext/src/analysis.py
+++ b/modules/spatiotemporal/pyext/src/analysis.py
@@ -81,7 +81,7 @@ def temporal_precision(labeled_pdf1_fn, labeled_pdf2_fn,
 def precision(labeled_pdf_fn, output_fn='precision.txt'):
     """
     Function that reads in one labeled_pdf from create_DAG and returns the
-    precision, defined as the sum of the squared 
+    precision, defined as the sum of the squared
     probability of all trajectories.
 
     @param labeled_pdf_fn: string, labeled pdf file name (including the path);

--- a/modules/spatiotemporal/pyext/src/analysis.py
+++ b/modules/spatiotemporal/pyext/src/analysis.py
@@ -81,7 +81,8 @@ def temporal_precision(labeled_pdf1_fn, labeled_pdf2_fn,
 def precision(labeled_pdf_fn, output_fn='precision.txt'):
     """
     Function that reads in one labeled_pdf from create_DAG and returns the
-    precision, defined as the sum of the squared probability of all trajectories.
+    precision, defined as the sum of the squared 
+    probability of all trajectories.
 
     @param labeled_pdf_fn: string, labeled pdf file name (including the path);
            labeled_pdf from the total model


### PR DESCRIPTION
Changes the name of purity to precision in spatiotemporal. This matches the text in the manuscript